### PR TITLE
switch over to gha envs with standard names

### DIFF
--- a/.github/workflows/fly-auto-deploy-production.yml
+++ b/.github/workflows/fly-auto-deploy-production.yml
@@ -15,12 +15,12 @@ jobs:
       changelog: ${{ github.event.release.body }}
       commitish: ${{ github.event.release.tag_name }}
       deeplink: ${{ github.event.release.html_url }}
-      environment: lightward.ai
+      environment: production
 
   fly-secrets:
     name: Fly secrets
     uses: ./.github/workflows/fly-secrets.yml
     secrets: inherit
     with:
-      environment: lightward.ai
+      environment: production
       stage_only: true

--- a/.github/workflows/fly-auto-deploy-staging.yml
+++ b/.github/workflows/fly-auto-deploy-staging.yml
@@ -15,11 +15,11 @@ jobs:
       changelog: ${{ github.event.release.body }}
       commitish: ${{ github.event.release.tag_name }}
       deeplink: ${{ github.event.release.html_url }}
-      environment: staging.lightward.ai
+      environment: staging
 
   fly-secrets:
     name: Fly secrets
     uses: ./.github/workflows/fly-secrets.yml
     secrets: inherit
     with:
-      environment: staging.lightward.ai
+      environment: staging

--- a/.github/workflows/fly-manual-deploy.yml
+++ b/.github/workflows/fly-manual-deploy.yml
@@ -11,7 +11,7 @@ on:
       environment:
         description: Environment
         required: true
-        default: staging.lightward.ai
+        default: staging
         type: environment
       notes:
         description: Deploy notes

--- a/.github/workflows/fly-manual-secrets.yml
+++ b/.github/workflows/fly-manual-secrets.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: Environment
         required: true
-        default: staging.lightward.ai
+        default: staging
         type: environment
       update_behavior:
         description: Update mode

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     uses: lightward/.github-private/.github/workflows/fly-build.yml@main
     with:
       commitish: ${{ inputs.sha }}
-      environment: lightward.ai
+      environment: staging
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-primer-refresh.yml
+++ b/.github/workflows/weekly-primer-refresh.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   run-rake-tasks:
     runs-on: ubuntu-latest
-    environment: lightward.ai
+    environment: staging
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
"production" and "staging", instead of "lightward.ai" and "staging.lightward.ai". this is for consistency with our other gha environment configurations, in other project repos.

this pr also repoints our definition of "production" from lightward-ai to lightward-ai-production on fly.io