### PR TITLE
fix (mostly?) draft replies

### DIFF
--- a/app/lib/helpscout.rb
+++ b/app/lib/helpscout.rb
@@ -70,7 +70,7 @@ module Helpscout
       end
     end
 
-    def create_draft_reply(conversation_id, body)
+    def create_draft_reply(conversation_id, body, customer_id:)
       token = cached_auth_token
 
       response = HTTParty.post(
@@ -83,6 +83,9 @@ module Helpscout
           text: body,
           draft: true,
           user: user_id,
+          customer: {
+            id: customer_id,
+          },
         }.to_json,
       )
 


### PR DESCRIPTION
those requests are still 404'ing, not sure why - I wrote to helpscout about it. convo ID is valid, it's GETable, notes can be added, but writing replies are 404'ing. weird. still! this code is still progress from what's in main. ;)