### PR TITLE
put client-specific caching back

### DIFF
--- a/app/lib/prompts.rb
+++ b/app/lib/prompts.rb
@@ -147,6 +147,9 @@ module Prompts
           array << { role: role, content: [{ type: "text", text: File.read(file).strip }] }
         end
 
+        # Establish a cacheable prefix, as of that last message
+        array.last[:content].last[:cache_control] = { type: "ephemeral" }
+
         array.freeze
       end
     end

--- a/spec/lib/prompts_spec.rb
+++ b/spec/lib/prompts_spec.rb
@@ -147,6 +147,11 @@ RSpec.describe(Prompts, :aggregate_failures) do
       expect(conversation_starters).to(all(have_key(:content)))
     end
 
+    it "has a cache flag on the last message, and the last message only" do
+      expect(conversation_starters.last[:content].last[:cache_control]).to(eq(type: "ephemeral"))
+      expect(conversation_starters[0..-2].all? { |starter| starter[:content].all? { |content| content[:cache_control].nil? } }).to(be(true))
+    end
+
     it "is validly sorted" do
       expect(conversation_starters.pluck(:role)).to(eq(["user", "assistant"] * (conversation_starters.size / 2)))
     end


### PR DESCRIPTION
https://lightward.slack.com/archives/C07411V29A7/p1747769439117559

removed in 326d79f7a6dc2dc1f9823bf326ddb6d6c298f9e3