### PR TITLE
Potential fix for code scanning alert no. 44: Potentially uninitialized local variable

### DIFF
--- a/app/jobs/helpscout_job.rb
+++ b/app/jobs/helpscout_job.rb
@@ -101,7 +101,7 @@ class HelpscoutJob < ApplicationJob
       messages: messages,
     )
   rescue => error
-    slack_client.chat_postMessage(channel: "#ai-logs", text: <<~eod.squish, thread_ts: slack_message["ts"])
+    slack_client.chat_postMessage(channel: "#ai-logs", text: <<~eod.squish, thread_ts: slack_message&.dig("ts"))
       Error processing Help Scout webhook for conversation #{convo_id}: #{error.message}
     eod
 


### PR DESCRIPTION
Potential fix for [https://github.com/lightward/lightward-ai/security/code-scanning/44](https://github.com/lightward/lightward-ai/security/code-scanning/44)

To fix the issue, we need to ensure that the `rescue` block can handle the case where `slack_message` is uninitialized. This can be achieved by using the safe navigation operator (`&.`) when accessing `slack_message["ts"]`. This operator will prevent a `NoMethodError` if `slack_message` is `nil`. Additionally, we can provide a fallback value (e.g., `nil`) for the `thread_ts` parameter in the `chat_postMessage` call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
