### PR TITLE
Add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@
 
 node_modules
 coverage
+
+# Claude Code configuration
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Added CLAUDE.md to .gitignore to prevent Claude Code configuration from being tracked in version control

## Test plan
- [x] Verify .gitignore includes CLAUDE.md entry
- [x] Confirm CLAUDE.md is no longer tracked by git
- [x] No rubocop issues