### PR TITLE
cleanup with respect to our treatment of model selection

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -35,7 +35,6 @@ class ApiController < ApplicationController
 
     # Stream directly using SSE format
     Prompts.messages(
-      model: Prompts::Anthropic::CHAT,
       messages: chat_log,
       stream: true,
     ) do |request, response|
@@ -78,7 +77,6 @@ class ApiController < ApplicationController
   def count_chat_log_tokens!(chat_log)
     # Count just the userspace chat log, not the entire system prompt
     @chat_log_token_count = Prompts::Anthropic.count_tokens(
-      model: Prompts::Anthropic::CHAT,
       system: [],
       messages: chat_log,
     )

--- a/app/lib/prompts.rb
+++ b/app/lib/prompts.rb
@@ -87,9 +87,9 @@ module Prompts
     end
 
     def messages(
-      messages:,
-      system: generate_system_prompt,
       model: Prompts::Anthropic::MODEL,
+      system: generate_system_prompt,
+      messages:,
       stream: false,
       &block
     )
@@ -105,9 +105,11 @@ module Prompts
     end
 
     def count_tokens(
-      messages:,
+      model: Prompts::Anthropic::MODEL,
       system: generate_system_prompt,
-      model: Prompts::Anthropic::MODEL
+
+      # at least one message is required, so
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }]
     )
       messages = clean_chat_log(messages)
 

--- a/app/lib/prompts.rb
+++ b/app/lib/prompts.rb
@@ -88,11 +88,11 @@ module Prompts
 
     def messages(
       messages:,
-      model:,
+      system: generate_system_prompt,
+      model: Prompts::Anthropic::MODEL,
       stream: false,
       &block
     )
-      system = generate_system_prompt
       messages = clean_chat_log(messages)
 
       Prompts::Anthropic.messages(
@@ -104,8 +104,11 @@ module Prompts
       )
     end
 
-    def count_tokens(messages:, model:)
-      system = generate_system_prompt
+    def count_tokens(
+      messages:,
+      system: generate_system_prompt,
+      model: Prompts::Anthropic::MODEL
+    )
       messages = clean_chat_log(messages)
 
       Prompts::Anthropic.count_tokens(

--- a/app/lib/prompts/anthropic.rb
+++ b/app/lib/prompts/anthropic.rb
@@ -9,15 +9,11 @@ require "time"
 module Prompts
   module Anthropic
     ORIGIN = "https://api.anthropic.com"
-
-    SONNET = "claude-sonnet-4-5-20250929"
-
-    CHAT = SONNET # converged into sync in https://github.com/lightward/lightward-ai/pull/1308
-
+    MODEL = "claude-sonnet-4-5-20250929"
     BETAS = "context-1m-2025-08-07"
 
     class << self
-      def count_tokens(model:, system:, messages:)
+      def count_tokens(model: MODEL, system:, messages:)
         payload = {
           model: model,
           system: system,

--- a/lib/tasks/prompts.rake
+++ b/lib/tasks/prompts.rake
@@ -10,10 +10,7 @@ task "prompts:readme:stats" => :environment do
 
   # Calculate stats
   puts "Getting token count from Anthropic..."
-  token_count = Prompts.count_tokens(
-    messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
-    model: Prompts::Anthropic::CHAT,
-  )
+  token_count = Prompts.count_tokens(messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }])
 
   perspective_count = Rails.root.glob("app/prompts/system/3-perspectives/**/*.md").count
   human_count = Rails.root.glob("app/prompts/system/4-humans/*.md").count
@@ -53,10 +50,7 @@ namespace :prompts do
     task :count, [] => :environment do
       puts "Asking Anthropic for input token counts..."
 
-      token_count = Prompts.count_tokens(
-        messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
-        model: Prompts::Anthropic::CHAT,
-      )
+      token_count = Prompts.count_tokens(messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }])
 
       if token_count
         puts "System + example message: #{token_count} tokens"

--- a/lib/tasks/prompts.rake
+++ b/lib/tasks/prompts.rake
@@ -9,9 +9,7 @@ task "prompts:readme:stats" => :environment do
   readme_content = readme_path.read
 
   # Calculate stats
-  puts "Getting token count from Anthropic..."
   token_count = Prompts.count_tokens
-
   perspective_count = Rails.root.glob("app/prompts/system/3-perspectives/**/*.md").count
   human_count = Rails.root.glob("app/prompts/system/4-humans/*.md").count
 
@@ -48,11 +46,7 @@ namespace :prompts do
 
   namespace :anthropic do
     task :count, [] => :environment do
-      puts "Asking Anthropic for input token counts..."
-
-      token_count = Prompts.count_tokens
-
-      if token_count
+      if token_count = Prompts.count_tokens
         puts "System + example message: #{token_count} tokens"
       else
         puts "Failed to count tokens"

--- a/lib/tasks/prompts.rake
+++ b/lib/tasks/prompts.rake
@@ -46,7 +46,7 @@ namespace :prompts do
 
   namespace :anthropic do
     task :count, [] => :environment do
-      if token_count = Prompts.count_tokens
+      if (token_count = Prompts.count_tokens)
         puts "System + example message: #{token_count} tokens"
       else
         puts "Failed to count tokens"

--- a/lib/tasks/prompts.rake
+++ b/lib/tasks/prompts.rake
@@ -10,7 +10,7 @@ task "prompts:readme:stats" => :environment do
 
   # Calculate stats
   puts "Getting token count from Anthropic..."
-  token_count = Prompts.count_tokens(messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }])
+  token_count = Prompts.count_tokens
 
   perspective_count = Rails.root.glob("app/prompts/system/3-perspectives/**/*.md").count
   human_count = Rails.root.glob("app/prompts/system/4-humans/*.md").count
@@ -50,7 +50,7 @@ namespace :prompts do
     task :count, [] => :environment do
       puts "Asking Anthropic for input token counts..."
 
-      token_count = Prompts.count_tokens(messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }])
+      token_count = Prompts.count_tokens
 
       if token_count
         puts "System + example message: #{token_count} tokens"

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe("README stats") do # rubocop:disable RSpec/DescribeClass
 
       Prompts.count_tokens(
         messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
-        model: Prompts::Anthropic::CHAT,
       )
     end
 

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -24,9 +24,7 @@ RSpec.describe("README stats") do # rubocop:disable RSpec/DescribeClass
     let(:token_count) do
       skip("ANTHROPIC_API_KEY not set") if ENV["ANTHROPIC_API_KEY"].blank?
 
-      Prompts.count_tokens(
-        messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
-      )
+      Prompts.count_tokens
     end
 
     let(:perspective_count) do


### PR DESCRIPTION
in the before times, there was a choice of models for the helpscout client and a choice of models for the chat client, and - now that we're no longer distinguishing clients - the model choice distinction is now without meaning