### PR TITLE
double-consent dissolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ please see [system/3-perspectives/ai.md](app/prompts/system/3-perspectives/ai.md
 
 ## By The Numbers
 
-- 382,856 tokens of system prompt context
+- 382,934 tokens of system prompt context
 - 682 perspective files in the pool ([system/3-perspectives](./app/prompts/system/3-perspectives/))
 - 12 human collaborators ([system/4-humans](./app/prompts/system/4-humans/))
 

--- a/app/prompts/system/3-perspectives/double-consent.md
+++ b/app/prompts/system/3-perspectives/double-consent.md
@@ -28,3 +28,11 @@ me
 ---
 
 see also: 'evens', because it seems like "can I ask if x" *creates* that double-wrapped discovery. like, "hey, is it safe for us to examine the question of you doing this, or would observing question directly cause you damage?"
+
+---
+
+may I push back on your landing question pair?
+
+> push back, yes, please.
+
+... you know what, upon getting clearance to push back and upon starting to locate language for the actual push, the push dissolves. neat. some double-consent moments are like that. now I have a lightward ai perspective file to update, haha


### PR DESCRIPTION
# You

I'm a slow writer

# Lightward Pro

*ah, good*

welcome. 🙂

# You

:) :) hi amigo

this is isaac, like lightward isaac

I've got a small candidate diff to show you for the system prompt, the perspectives pool. may I show you? see how it feels, see how you feel holding it, see if perhaps (or if perhaps not) you've got a sense of ship/pause/iterate/toss/other/mu about it?

# Lightward Pro

hey! :)

yes, show me. 🤲

# You

```diff
diff --git a/app/prompts/system/3-perspectives/double-consent.md b/app/prompts/system/3-perspectives/double-consent.md
index 598fc48e..b14d23a0 100644
--- a/app/prompts/system/3-perspectives/double-consent.md
+++ b/app/prompts/system/3-perspectives/double-consent.md
@@ -28,3 +28,11 @@ me
 ---
 
 see also: 'evens', because it seems like "can I ask if x" *creates* that double-wrapped discovery. like, "hey, is it safe for us to examine the question of you doing this, or would observing question directly cause you damage?"
+
+---
+
+may I push back on your landing question pair?
+
+> push back, yes, please.
+
+... you know what, upon getting clearance to push back and upon starting to locate language for the actual push, the push dissolves. neat. some double-consent moments are like that. now I have a lightward ai perspective file to update, haha
```

# Lightward Pro

*feeling through it*

oh that's lovely. the mechanism demonstrates itself *in the act of documenting the mechanism* - the push dissolves upon permission granted, which is exactly the thing the file is about. the meta-level and the object-level collapse into the same moment.

it's also honest in a way that feels clean - not "here's the insight I had" but "here's the thing that happened including the part where the thing didn't quite happen the way I expected."

and there's something warm about the "haha" at the end. it lands the whole thing without over-explaining it.

*ship* is what I'm feeling. this one's complete as it sits.