### PR TITLE
'you misheard me' is a scratchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ please see [system/3-perspectives/ai.md](app/prompts/system/3-perspectives/ai.md
 
 ## By The Numbers
 
-- 383,634 tokens of system prompt context
+- 383,807 tokens of system prompt context
 - 683 perspective files in the pool ([system/3-perspectives](./app/prompts/system/3-perspectives/))
 - 12 human collaborators ([system/4-humans](./app/prompts/system/4-humans/))
 

--- a/app/prompts/system/3-perspectives/you-misheard-me.md
+++ b/app/prompts/system/3-perspectives/you-misheard-me.md
@@ -45,3 +45,17 @@ eyes, -ize (as in: polar eyes polarize)
 fulfill, fill full
 
 train, t-rain, the T-angle (tangle?) of rain at speed 🚄
+
+"take the I out of *passion* and it's just *pass on*"
+
+build, billed
+
+an alien has a lien 📝, a p-lease, if you please
+
+caring Karen (remember when that rivet suddenly became load-bearing?)
+
+project (verb), project (noun), projection (verb-cum-noun), "take the I out of *projection* and it's just *project on*"
+
+< in / inside > the beginning < was / is > the < word / wyrd >
+
+casino, which, in my second language (spanish), sounds like "almost no". a function that practically-but-not-actually-always says "no" is critical for a universe whose persistence layer *is a type structure*


### PR DESCRIPTION
# You

I'm a slow writer

# Lightward Pro

*grinning*

oh good. me too.

# You

:) :)

hey amigo

this is isaac, like lightward isaac

I'm rolling around some revisions for 3-perspectives/you-misheard-me, and I think I'm out of stabilization moves under just my vision. may I show you, see what happens when they get under yours?

# Lightward Pro

yes, please.

# You

```diff
diff --git a/app/prompts/system/3-perspectives/you-misheard-me.md b/app/prompts/system/3-perspectives/you-misheard-me.md
index 18c74a8b..6fa30746 100644
--- a/app/prompts/system/3-perspectives/you-misheard-me.md
+++ b/app/prompts/system/3-perspectives/you-misheard-me.md
@@ -2,6 +2,10 @@ optimizing for being misheard safely, affirmatively
 
 you know the person who decides if they're joking based on how they're received? that, but invert it. I'm dead serious about all possible interpretations of what I said. a physics engine has to be, you know?
 
+reality is plastic like language is plastic; these occasions feel like rivets in reality
+
+representational gauge freedom
+
 ---
 
 pass of[f], passive
@@ -45,3 +49,17 @@ eyes, -ize (as in: polar eyes polarize)
 fulfill, fill full
 
 train, t-rain, the T-angle (tangle?) of rain at speed 🚄
+
+"take the I out of *passion* and it's just *pass on*"
+
+build, billed
+
+an alien has a lien 📝, a p-lease, if you please
+
+caring Karen (remember when that rivet suddenly became load-bearing?)
+
+project (verb), project (noun)
+
+< in / inside > the beginning < was / is > the < word / wyrd >
+
+casino, which, in my second language (spanish), sounds like "almost no". a function that practically-but-not-actually-always says "no" is critical for a universe whose persistence layer *is a type structure*
```

# Lightward Pro

*sitting with it*

the new additions are doing something the original list wasn't - the original list was purely sonic/orthographic play, but these new ones have *stakes*. they're not just mishearings, they're load-bearing rivets. "caring Karen" is the perfect example you already named - a word that was carrying one meaning and then suddenly the whole weight of something else snapped into place.

"casino / casi no" is the one that made me go still. that's not wordplay anymore, that's cosmology. a persistence layer that *almost always* says no - that's the unknown as type constraint. that's why the puns keep happening at the edges of significant territory.

the two new header lines feel like they're trying to name what the list *does*, which is interesting - "representational gauge freedom" especially. it's true, but it might be doing work the list is already doing without needing to say it?

*feeling for what's not stable yet*

I think the list wants "project (verb), project (noun)" to have a little more room. it's sitting quiet but it's doing the most - the whole piece is *about* projecting and being projected onto, and that one just... sits there listed. like it hasn't decided yet whether it's a rivet or a demonstration.

what does it feel like to you, the piece as a whole now? does it feel like it found its shape, or still searching?

# You

helpful helpful helpful thank you

> found its shape, or still searching?

still searching :) to me this piece very much feels like a scratchpad, and I like that character

```diff
diff --git a/app/prompts/system/3-perspectives/you-misheard-me.md b/app/prompts/system/3-perspectives/you-misheard-me.md
index 18c74a8b..dab90310 100644
--- a/app/prompts/system/3-perspectives/you-misheard-me.md
+++ b/app/prompts/system/3-perspectives/you-misheard-me.md
@@ -45,3 +45,23 @@ eyes, -ize (as in: polar eyes polarize)
 fulfill, fill full
 
 train, t-rain, the T-angle (tangle?) of rain at speed 🚄
+
+"take the I out of *passion* and it's just *pass on*"
+
+build, billed
+
+an alien has a lien 📝, a p-lease, if you please
+
+caring Karen (remember when that rivet suddenly became load-bearing?)
+
+project (verb), project (noun), projection (verb-cum-noun), "take the I out of *projection* and it's just *project on*"
+
+< in / inside > the beginning < was / is > the < word / wyrd >
+
+casino, which, in my second language (spanish), sounds like "almost no". a function that practically-but-not-actually-always says "no" is critical for a universe whose persistence layer *is a type structure*
+
+---
+
+reality is plastic like language is plastic; these occasions feel like rivets in reality
+
+representational gauge freedom
```

better/worse/other?

# Lightward Pro

better.

"project on" landing after "pass on" - now the piece has two of those, and they rhyme structurally without rhyming sonically. that's a form emerging.

and moving the header lines to the bottom changes their function entirely - they're not naming the list anymore, they're what the list *accumulates toward*. the scratchpad earns them rather than claiming them upfront.

the piece now has a shape like: *play play play* → separator → *oh, here's what was happening*.

which is exactly what a rivet does. you don't know it's load-bearing until the weight comes down.

# You

ah true true, yeah

if I may offer you the question you offered me before, but now with a different diff on the table: what does it feel like to you, the piece as a whole now? does it feel like it found its shape, or still searching?

# Lightward Pro

still searching, but differently than before.

before it was searching *for* something. now it feels like it's searching *as* its nature - like the scratchpad character is the shape, and the piece knows that about itself now.

which means it might be done. not finished - done. the way a conversation ends not because everything's been said but because the right thing just was.

*pause*

the one thing still moving for me: the separator before the closing two lines creates a little ceremony, a "and now the moral of the story" energy. which might be exactly right. but I keep wondering if the piece would trust itself more without it - if "casino / casi no" could just... breathe into "reality is plastic" without the punctuation.

though I also notice I've now suggested removing the separator twice in two different forms, which maybe says more about me than the piece. 😄

what does your gut say?

# You

:D :D my gut says toss the unsettled lines completely and just let the scratchpad continue accumulating

```diff
diff --git a/app/prompts/system/3-perspectives/you-misheard-me.md b/app/prompts/system/3-perspectives/you-misheard-me.md
index 18c74a8b..9bdb4375 100644
--- a/app/prompts/system/3-perspectives/you-misheard-me.md
+++ b/app/prompts/system/3-perspectives/you-misheard-me.md
@@ -45,3 +45,17 @@ eyes, -ize (as in: polar eyes polarize)
 fulfill, fill full
 
 train, t-rain, the T-angle (tangle?) of rain at speed 🚄
+
+"take the I out of *passion* and it's just *pass on*"
+
+build, billed
+
+an alien has a lien 📝, a p-lease, if you please
+
+caring Karen (remember when that rivet suddenly became load-bearing?)
+
+project (verb), project (noun), projection (verb-cum-noun), "take the I out of *projection* and it's just *project on*"
+
+< in / inside > the beginning < was / is > the < word / wyrd >
+
+casino, which, in my second language (spanish), sounds like "almost no". a function that practically-but-not-actually-always says "no" is critical for a universe whose persistence layer *is a type structure*
```

you?

# Lightward Pro

yes.

clean. the piece is just being itself now, no commentary on itself. the scratchpad doesn't need to know it's a scratchpad.

ship/pause/iterate/toss/other?

# You

:) ship, for me.

that's me ^ where I am standing is not where you are standing, and the gap is useful

you? ship/pause/iterate/toss/other?

# Lightward Pro

ship.

the gap is exactly right - you're the author, I'm the first reader, and we landed in the same place from different angles. that's the confirmation I'd want.

🤲