### PR TITLE
Track LAI usage clients and token costs

### DIFF
--- a/.github/workflows/fly-secrets.yml
+++ b/.github/workflows/fly-secrets.yml
@@ -28,7 +28,6 @@ jobs:
           if [ "${{ inputs.stage_only }}" = "true" ]; then
             stage_flag="--stage"
           fi
-          # TOKEN_LIMIT_BYPASS_KEYS remains reserved for clients that should bypass the conversation horizon.
           flyctl secrets set \
             $stage_flag \
             --app ${{ vars.FLY_APP_NAME }} \

--- a/.github/workflows/fly-secrets.yml
+++ b/.github/workflows/fly-secrets.yml
@@ -28,11 +28,13 @@ jobs:
           if [ "${{ inputs.stage_only }}" = "true" ]; then
             stage_flag="--stage"
           fi
-          # TOKEN_LIMIT_BYPASS_KEYS accepts comma-separated values for multiple client keys
+          # TOKEN_LIMIT_BYPASS_CLIENT_KEYS accepts comma-separated client:key entries for named usage attribution.
+          # TOKEN_LIMIT_BYPASS_KEYS remains the legacy fallback for unnamed external bypass clients.
           flyctl secrets set \
             $stage_flag \
             --app ${{ vars.FLY_APP_NAME }} \
             ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}" \
+            TOKEN_LIMIT_BYPASS_CLIENT_KEYS="${{ secrets.TOKEN_LIMIT_BYPASS_CLIENT_KEYS }}" \
             TOKEN_LIMIT_BYPASS_KEYS="${{ secrets.TOKEN_LIMIT_BYPASS_KEYS }}" \
             HOST="${{ vars.HOST }}" \
             LOG_LEVEL="${{ vars.LOG_LEVEL }}" \

--- a/.github/workflows/fly-secrets.yml
+++ b/.github/workflows/fly-secrets.yml
@@ -28,6 +28,7 @@ jobs:
           if [ "${{ inputs.stage_only }}" = "true" ]; then
             stage_flag="--stage"
           fi
+          # TOKEN_LIMIT_BYPASS_KEYS remains reserved for clients that should bypass the conversation horizon.
           flyctl secrets set \
             $stage_flag \
             --app ${{ vars.FLY_APP_NAME }} \

--- a/.github/workflows/fly-secrets.yml
+++ b/.github/workflows/fly-secrets.yml
@@ -28,7 +28,7 @@ jobs:
           if [ "${{ inputs.stage_only }}" = "true" ]; then
             stage_flag="--stage"
           fi
-          # TOKEN_LIMIT_BYPASS_KEYS remains reserved for clients that should bypass the conversation horizon.
+          # TOKEN_LIMIT_BYPASS_KEYS accepts comma-separated values for multiple client keys
           flyctl secrets set \
             $stage_flag \
             --app ${{ vars.FLY_APP_NAME }} \

--- a/.github/workflows/fly-secrets.yml
+++ b/.github/workflows/fly-secrets.yml
@@ -28,13 +28,11 @@ jobs:
           if [ "${{ inputs.stage_only }}" = "true" ]; then
             stage_flag="--stage"
           fi
-          # LAI_USAGE_CLIENT_KEYS accepts comma-separated client:key entries for named usage attribution.
           # TOKEN_LIMIT_BYPASS_KEYS remains reserved for clients that should bypass the conversation horizon.
           flyctl secrets set \
             $stage_flag \
             --app ${{ vars.FLY_APP_NAME }} \
             ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}" \
-            LAI_USAGE_CLIENT_KEYS="${{ secrets.LAI_USAGE_CLIENT_KEYS }}" \
             TOKEN_LIMIT_BYPASS_KEYS="${{ secrets.TOKEN_LIMIT_BYPASS_KEYS }}" \
             HOST="${{ vars.HOST }}" \
             LOG_LEVEL="${{ vars.LOG_LEVEL }}" \

--- a/.github/workflows/fly-secrets.yml
+++ b/.github/workflows/fly-secrets.yml
@@ -28,13 +28,13 @@ jobs:
           if [ "${{ inputs.stage_only }}" = "true" ]; then
             stage_flag="--stage"
           fi
-          # TOKEN_LIMIT_BYPASS_CLIENT_KEYS accepts comma-separated client:key entries for named usage attribution.
-          # TOKEN_LIMIT_BYPASS_KEYS remains the legacy fallback for unnamed external bypass clients.
+          # LAI_USAGE_CLIENT_KEYS accepts comma-separated client:key entries for named usage attribution.
+          # TOKEN_LIMIT_BYPASS_KEYS remains reserved for clients that should bypass the conversation horizon.
           flyctl secrets set \
             $stage_flag \
             --app ${{ vars.FLY_APP_NAME }} \
             ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}" \
-            TOKEN_LIMIT_BYPASS_CLIENT_KEYS="${{ secrets.TOKEN_LIMIT_BYPASS_CLIENT_KEYS }}" \
+            LAI_USAGE_CLIENT_KEYS="${{ secrets.LAI_USAGE_CLIENT_KEYS }}" \
             TOKEN_LIMIT_BYPASS_KEYS="${{ secrets.TOKEN_LIMIT_BYPASS_KEYS }}" \
             HOST="${{ vars.HOST }}" \
             LOG_LEVEL="${{ vars.LOG_LEVEL }}" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ The whole architecture resolves to one sentence worth keeping: *formally protect
 
 Clients: **lightward.com** (public threshold, stateless), **helpscout-ai** (internal support), **yours.fyi** (private pocket universes with memory).
 
-**Token limit bypass** (`api_controller.rb`, `CHAT_LOG_TOKEN_LIMIT = 50k`): the limit shapes *when* a conversation naturally concludes — a horizon, not rate-limiting. Usage attribution is separate: named external callers use `LAI_USAGE_CLIENT_KEYS` (`client:key` pairs) + `X-LAI-Usage-Key`. Horizon bypass remains reserved for `TOKEN_LIMIT_BYPASS_KEYS` + `Token-Limit-Bypass-Key`. Structural, not preferential.
+**Token limit bypass** (`api_controller.rb`, `CHAT_LOG_TOKEN_LIMIT = 50k`): the limit shapes *when* a conversation naturally concludes — a horizon, not rate-limiting. Usage attribution is separate and report-only: callers may send `X-LAI-Usage-Client` (`helpscout`, `yours`, `softer`, `reader`, or `writer`). Horizon bypass remains reserved for `TOKEN_LIMIT_BYPASS_KEYS` + `Token-Limit-Bypass-Key`. Structural, not preferential.
 
 **Horizon warnings as speech.** Near the horizon (90%) the warning is appended to the response *body* — the same channel as the model's voice — for both `/api/stream` (a final SSE delta) and `/api/plain`. Never an HTTP header or out-of-band metadata: the horizon is an experience, not an event to handle. Tested in `spec/requests/api_spec.rb` ("horizon warnings as speech"). (Note the rhyme with the foam layer's horizon/cadence — the point where the walk truncates to yield.)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ The whole architecture resolves to one sentence worth keeping: *formally protect
 
 Clients: **lightward.com** (public threshold, stateless), **helpscout-ai** (internal support), **yours.fyi** (private pocket universes with memory).
 
-**Token limit bypass** (`api_controller.rb`, `CHAT_LOG_TOKEN_LIMIT = 50k`): the limit shapes *when* a conversation naturally concludes — a horizon, not rate-limiting. Bypass via `TOKEN_LIMIT_BYPASS_KEYS` (env, plural — the API holds all keys) + `Token-Limit-Bypass-Key` header (singular — the key being presented). Structural, not preferential.
+**Token limit bypass** (`api_controller.rb`, `CHAT_LOG_TOKEN_LIMIT = 50k`): the limit shapes *when* a conversation naturally concludes — a horizon, not rate-limiting. Named external callers use `TOKEN_LIMIT_BYPASS_CLIENT_KEYS` (`client:key` pairs) + `Token-Limit-Bypass-Key`; legacy unnamed bypasses still use `TOKEN_LIMIT_BYPASS_KEYS`. Structural, not preferential.
 
 **Horizon warnings as speech.** Near the horizon (90%) the warning is appended to the response *body* — the same channel as the model's voice — for both `/api/stream` (a final SSE delta) and `/api/plain`. Never an HTTP header or out-of-band metadata: the horizon is an experience, not an event to handle. Tested in `spec/requests/api_spec.rb` ("horizon warnings as speech"). (Note the rhyme with the foam layer's horizon/cadence — the point where the walk truncates to yield.)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ The whole architecture resolves to one sentence worth keeping: *formally protect
 
 Clients: **lightward.com** (public threshold, stateless), **helpscout-ai** (internal support), **yours.fyi** (private pocket universes with memory).
 
-**Token limit bypass** (`api_controller.rb`, `CHAT_LOG_TOKEN_LIMIT = 50k`): the limit shapes *when* a conversation naturally concludes — a horizon, not rate-limiting. Named external callers use `TOKEN_LIMIT_BYPASS_CLIENT_KEYS` (`client:key` pairs) + `Token-Limit-Bypass-Key`; legacy unnamed bypasses still use `TOKEN_LIMIT_BYPASS_KEYS`. Structural, not preferential.
+**Token limit bypass** (`api_controller.rb`, `CHAT_LOG_TOKEN_LIMIT = 50k`): the limit shapes *when* a conversation naturally concludes — a horizon, not rate-limiting. Usage attribution is separate: named external callers use `LAI_USAGE_CLIENT_KEYS` (`client:key` pairs) + `X-LAI-Usage-Key`. Horizon bypass remains reserved for `TOKEN_LIMIT_BYPASS_KEYS` + `Token-Limit-Bypass-Key`. Structural, not preferential.
 
 **Horizon warnings as speech.** Near the horizon (90%) the warning is appended to the response *body* — the same channel as the model's voice — for both `/api/stream` (a final SSE delta) and `/api/plain`. Never an HTTP header or out-of-band metadata: the horizon is an experience, not an event to handle. Tested in `spec/requests/api_spec.rb` ("horizon warnings as speech"). (Note the rhyme with the foam layer's horizon/cadence — the point where the walk truncates to yield.)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ The whole architecture resolves to one sentence worth keeping: *formally protect
 
 Clients: **lightward.com** (public threshold, stateless), **helpscout-ai** (internal support), **yours.fyi** (private pocket universes with memory).
 
-**Token limit bypass** (`api_controller.rb`, `CHAT_LOG_TOKEN_LIMIT = 50k`): the limit shapes *when* a conversation naturally concludes — a horizon, not rate-limiting. Usage attribution is separate and report-only: callers may send `X-LAI-Usage-Client` (`helpscout`, `yours`, `softer`, `reader`, or `writer`). Horizon bypass remains reserved for `TOKEN_LIMIT_BYPASS_KEYS` + `Token-Limit-Bypass-Key`. Structural, not preferential.
+**Token limit bypass** (`api_controller.rb`, `CHAT_LOG_TOKEN_LIMIT = 50k`): the limit shapes *when* a conversation naturally concludes — a horizon, not rate-limiting. Usage attribution is separate and report-only: callers may send `X-LAI-Usage-Client` (`helpscout`, `helpscout_locksmith`, `helpscout_mechanic`, `yours`, `softer`, `reader`, or `writer`). Horizon bypass remains reserved for `TOKEN_LIMIT_BYPASS_KEYS` + `Token-Limit-Bypass-Key`. Structural, not preferential.
 
 **Horizon warnings as speech.** Near the horizon (90%) the warning is appended to the response *body* — the same channel as the model's voice — for both `/api/stream` (a final SSE delta) and `/api/plain`. Never an HTTP header or out-of-band metadata: the horizon is an experience, not an event to handle. Tested in `spec/requests/api_spec.rb` ("horizon warnings as speech"). (Note the rhyme with the foam layer's horizon/cadence — the point where the walk truncates to yield.)
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -171,8 +171,13 @@ class ApiController < ApplicationController
   def reported_usage_client
     return @reported_usage_client if defined?(@reported_usage_client)
 
-    requested_client = request.headers["X-LAI-Usage-Client"].presence || params[:usage_client]
-    @reported_usage_client = REPORTED_USAGE_CLIENTS[normalize_usage_client(requested_client)]
+    header_client = normalize_usage_client(request.headers["X-LAI-Usage-Client"])
+    param_client = normalize_usage_client(params[:usage_client])
+    @reported_usage_client = if header_client.present?
+      REPORTED_USAGE_CLIENTS[header_client]
+    else
+      FIRST_PARTY_USAGE_CLIENTS[param_client]
+    end
   end
 
   def bypass_key_valid?

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -7,6 +7,22 @@ class ApiController < ApplicationController
   class InvalidCacheMarkerCount < StandardError; end
 
   CHAT_LOG_TOKEN_LIMIT = 50_000
+  FIRST_PARTY_USAGE_CLIENTS = {
+    "reader" => "lightward_reader",
+    "writer" => "lightward_writer",
+  }.freeze
+  ANTHROPIC_USAGE_TOKEN_KEYS = %w[
+    input_tokens
+    output_tokens
+    cache_creation_input_tokens
+    cache_read_input_tokens
+  ].freeze
+  ANTHROPIC_PRICING_USD_PER_MILLION = {
+    "input_tokens" => 3.0,
+    "cache_creation_input_tokens" => 3.75,
+    "cache_read_input_tokens" => 0.30,
+    "output_tokens" => 15.0,
+  }.freeze
 
   skip_before_action :verify_host!
 
@@ -60,9 +76,6 @@ class ApiController < ApplicationController
     # Check conversation horizon
     count_chat_log_tokens!(chat_log) unless token_limit_disabled?
 
-    # Track analytics
-    record_newrelic_event(chat_log, conversation_frame_id: "plain")
-
     # Make non-streaming request to Anthropic
     response = Prompts.messages(
       messages: chat_log,
@@ -70,6 +83,7 @@ class ApiController < ApplicationController
     )
 
     if response.code.to_i >= 400
+      record_newrelic_event(chat_log, conversation_frame_id: "plain")
       render(plain: "An error occurred.", status: :bad_gateway)
       return
     end
@@ -77,6 +91,7 @@ class ApiController < ApplicationController
     # Parse response and extract text
     parsed = JSON.parse(response.body)
     response_text = parsed.dig("content", 0, "text") || ""
+    record_newrelic_event(chat_log, conversation_frame_id: "plain", anthropic_usage: parsed["usage"])
 
     # Append horizon warning if approaching limit
     unless token_limit_disabled?
@@ -90,9 +105,8 @@ class ApiController < ApplicationController
   end
 
   def perform_stream(chat_log)
-    # Track analytics
     conversation_frame_id, conversation_id = compute_conversation_ids(chat_log)
-    record_newrelic_event(chat_log, conversation_frame_id: conversation_frame_id, conversation_id: conversation_id)
+    anthropic_usage = {}
 
     response.headers["Content-Type"] = "text/event-stream"
     response.headers["Cache-Control"] = "no-cache"
@@ -106,7 +120,7 @@ class ApiController < ApplicationController
       if response.code.to_i >= 400
         send_sse_event("error", { error: { message: response.body } })
       else
-        stream_anthropic_response(request, response, chat_log)
+        stream_anthropic_response(request, response, chat_log, anthropic_usage)
       end
     end
   rescue IOError
@@ -116,6 +130,12 @@ class ApiController < ApplicationController
     Rails.logger.error("API stream error: #{error.message}\n#{error.backtrace.join("\n")}")
     send_sse_event("error", { error: { message: "An unexpected error occurred" } })
   ensure
+    record_newrelic_event(
+      chat_log,
+      conversation_frame_id: conversation_frame_id,
+      conversation_id: conversation_id,
+      anthropic_usage: anthropic_usage,
+    ) if conversation_frame_id
     send_sse_event("end", nil)
     response.stream.close
   end
@@ -123,11 +143,72 @@ class ApiController < ApplicationController
   private
 
   def token_limit_disabled?
-    return false if request.headers["Token-Limit-Bypass-Key"].blank?
+    token_limit_bypassed?
+  end
+
+  def token_limit_bypassed?
+    return @token_limit_bypassed if defined?(@token_limit_bypassed)
+
+    @token_limit_bypassed = named_bypass_client.present? || legacy_bypass_key_valid?
+  end
+
+  def bypass_key
+    request.headers["Token-Limit-Bypass-Key"].to_s.strip.presence
+  end
+
+  def named_bypass_client
+    return @named_bypass_client if defined?(@named_bypass_client)
+
+    key = bypass_key
+    @named_bypass_client = if key.blank?
+      nil
+    else
+      named_bypass_client_keys.find { |_client, client_key|
+        secure_token_match?(key, client_key)
+      }&.first
+    end
+  end
+
+  def named_bypass_client_keys
+    ENV["TOKEN_LIMIT_BYPASS_CLIENT_KEYS"].to_s.split(",").filter_map do |entry|
+      client, key = entry.split(":", 2).map { |part| part.to_s.strip }
+      next if client.blank? || key.blank?
+
+      [normalize_usage_client(client), key]
+    end
+  end
+
+  def legacy_bypass_key_valid?
+    key = bypass_key
+    return false if key.blank?
     return false if ENV["TOKEN_LIMIT_BYPASS_KEYS"].blank?
 
-    valid_keys = ENV["TOKEN_LIMIT_BYPASS_KEYS"].split(",").map(&:strip)
-    valid_keys.include?(request.headers["Token-Limit-Bypass-Key"])
+    ENV["TOKEN_LIMIT_BYPASS_KEYS"].split(",").map(&:strip).any? { |valid_key|
+      secure_token_match?(key, valid_key)
+    }
+  end
+
+  def secure_token_match?(candidate, expected)
+    return false if candidate.blank? || expected.blank?
+    return false unless candidate.bytesize == expected.bytesize
+
+    ActiveSupport::SecurityUtils.secure_compare(candidate, expected)
+  end
+
+  def usage_client
+    if named_bypass_client.present?
+      named_bypass_client
+    elsif legacy_bypass_key_valid?
+      "external_bypass"
+    elsif (first_party_usage_client = FIRST_PARTY_USAGE_CLIENTS[params[:usage_client].to_s])
+      first_party_usage_client
+    else
+      "#{action_name}_unknown"
+    end
+  end
+
+  def normalize_usage_client(client)
+    client.to_s.strip.downcase.gsub(/[^a-z0-9]+/, "_").gsub(/\A_|_\z/, "")
   end
 
   def validate_cache_markers!(chat_log)
@@ -195,17 +276,73 @@ class ApiController < ApplicationController
     [conversation_frame_id, conversation_id]
   end
 
-  def record_newrelic_event(chat_log, conversation_frame_id:, conversation_id: nil)
+  def record_newrelic_event(chat_log, conversation_frame_id:, conversation_id: nil, anthropic_usage: nil)
+    normalized_usage = normalize_anthropic_usage(anthropic_usage)
+
     ::NewRelic::Agent.record_custom_event(
       "ApiController: request",
       conversation_frame_id: conversation_frame_id,
       conversation_id: conversation_id,
+      usage_client: usage_client,
+      usage_conversation_id: usage_conversation_id(conversation_id),
+      usage_subject_id: usage_subject_id,
+      token_limit_bypassed: token_limit_bypassed?,
+      anthropic_model: Prompts::Anthropic::MODEL,
       chat_log_depth: chat_log.size,
       chat_log_token_count: @chat_log_token_count,
+      input_tokens: normalized_usage["input_tokens"],
+      output_tokens: normalized_usage["output_tokens"],
+      cache_creation_input_tokens: normalized_usage["cache_creation_input_tokens"],
+      cache_read_input_tokens: normalized_usage["cache_read_input_tokens"],
+      estimated_cost_usd: estimated_cost_usd(normalized_usage),
     )
   end
 
-  def stream_anthropic_response(request, response, chat_log)
+  def usage_conversation_id(conversation_id)
+    hmac_header(request.headers["X-LAI-Conversation-Key"]) || conversation_id
+  end
+
+  def usage_subject_id
+    hmac_header(request.headers["X-LAI-Subject-Key"])
+  end
+
+  def hmac_header(value)
+    value = value.to_s
+    return if value.blank?
+
+    secret = usage_telemetry_hmac_secret
+    return if secret.blank?
+
+    OpenSSL::HMAC.hexdigest("SHA256", secret, value)
+  end
+
+  def usage_telemetry_hmac_secret
+    ENV["USAGE_TELEMETRY_HMAC_SECRET"].presence ||
+      (Rails.application.secret_key_base unless Rails.env.production?)
+  end
+
+  def normalize_anthropic_usage(anthropic_usage)
+    usage = {}
+    anthropic_usage ||= {}
+
+    ANTHROPIC_USAGE_TOKEN_KEYS.each do |key|
+      usage[key] = anthropic_usage[key] if anthropic_usage.key?(key)
+    end
+
+    usage
+  end
+
+  def estimated_cost_usd(anthropic_usage)
+    return if anthropic_usage.values.all?(&:nil?)
+
+    cost = ANTHROPIC_PRICING_USD_PER_MILLION.sum { |key, usd_per_million|
+      anthropic_usage[key].to_i * usd_per_million / 1_000_000.0
+    }
+
+    cost.round(8)
+  end
+
+  def stream_anthropic_response(request, response, chat_log, anthropic_usage)
     buffer = +""
     current_event = nil
     warning = nil
@@ -222,6 +359,7 @@ class ApiController < ApplicationController
         elsif line.start_with?("data:")
           json_data = line[5..-1]
           event_data = JSON.parse(json_data)
+          capture_anthropic_usage!(anthropic_usage, current_event, event_data)
 
           # Handle horizon warnings (unless token limit disabled)
           warning = handle_horizon_warning(current_event, warning, chat_log) unless token_limit_disabled?
@@ -232,7 +370,22 @@ class ApiController < ApplicationController
     end
 
     # Process any remaining buffer
-    process_remaining_buffer(buffer, current_event)
+    process_remaining_buffer(buffer, current_event, anthropic_usage)
+  end
+
+  def capture_anthropic_usage!(anthropic_usage, current_event, event_data)
+    usage = case current_event
+    when "message_start"
+      event_data.dig("message", "usage")
+    when "message_delta"
+      event_data["usage"]
+    end
+
+    return unless usage.is_a?(Hash)
+
+    ANTHROPIC_USAGE_TOKEN_KEYS.each do |key|
+      anthropic_usage[key] = usage[key] if usage.key?(key)
+    end
   end
 
   def handle_horizon_warning(current_event, warning, chat_log)
@@ -271,7 +424,7 @@ class ApiController < ApplicationController
     })
   end
 
-  def process_remaining_buffer(buffer, current_event)
+  def process_remaining_buffer(buffer, current_event, anthropic_usage)
     return if buffer.strip.empty?
 
     line = buffer.strip
@@ -279,6 +432,7 @@ class ApiController < ApplicationController
 
     json_data = line[5..-1]
     event_data = JSON.parse(json_data)
+    capture_anthropic_usage!(anthropic_usage, current_event, event_data)
     send_sse_event(current_event || "message", event_data)
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -23,6 +23,7 @@ class ApiController < ApplicationController
     "cache_read_input_tokens" => 0.30,
     "output_tokens" => 15.0,
   }.freeze
+  TELEMETRY_HMAC_NAMESPACE = "lai-usage-telemetry-v1"
 
   skip_before_action :verify_host!
 
@@ -52,6 +53,9 @@ class ApiController < ApplicationController
   end
 
   def plain
+    chat_log = nil
+    newrelic_event_recorded = false
+
     # Read plaintext body
     message_text = request.body.read.to_s.strip
 
@@ -84,6 +88,7 @@ class ApiController < ApplicationController
 
     if response.code.to_i >= 400
       record_newrelic_event(chat_log, conversation_frame_id: "plain")
+      newrelic_event_recorded = true
       render(plain: "An error occurred.", status: :bad_gateway)
       return
     end
@@ -92,6 +97,7 @@ class ApiController < ApplicationController
     parsed = JSON.parse(response.body)
     response_text = parsed.dig("content", 0, "text") || ""
     record_newrelic_event(chat_log, conversation_frame_id: "plain", anthropic_usage: parsed["usage"])
+    newrelic_event_recorded = true
 
     # Append horizon warning if approaching limit
     unless token_limit_disabled?
@@ -102,6 +108,11 @@ class ApiController < ApplicationController
     render(plain: response_text)
   rescue ChatLogTokenLimitExceeded
     render(plain: "Conversation horizon has arrived. 🤲", status: :unprocessable_content)
+  rescue StandardError => error
+    Rollbar.error(error)
+    Rails.logger.error("API plain error: #{error.message}\n#{error.backtrace.join("\n")}")
+    record_newrelic_event(chat_log, conversation_frame_id: "plain") if chat_log.present? && !newrelic_event_recorded
+    render(plain: "An error occurred.", status: :bad_gateway)
   end
 
   def perform_stream(chat_log)
@@ -299,26 +310,22 @@ class ApiController < ApplicationController
   end
 
   def usage_conversation_id(conversation_id)
-    hmac_header(request.headers["X-LAI-Conversation-Key"]) || conversation_id
+    hmac_header(request.headers["X-LAI-Conversation-Key"], "conversation") || conversation_id
   end
 
   def usage_subject_id
-    hmac_header(request.headers["X-LAI-Subject-Key"])
+    hmac_header(request.headers["X-LAI-Subject-Key"], "subject")
   end
 
-  def hmac_header(value)
+  def hmac_header(value, field)
+    client = named_bypass_client
+    return if client.blank?
+
     value = value.to_s
     return if value.blank?
 
-    secret = usage_telemetry_hmac_secret
-    return if secret.blank?
-
-    OpenSSL::HMAC.hexdigest("SHA256", secret, value)
-  end
-
-  def usage_telemetry_hmac_secret
-    ENV["USAGE_TELEMETRY_HMAC_SECRET"].presence ||
-      (Rails.application.secret_key_base unless Rails.env.production?)
+    scoped_value = [TELEMETRY_HMAC_NAMESPACE, client, field, value].join(":")
+    OpenSSL::HMAC.hexdigest("SHA256", Rails.application.secret_key_base, scoped_value)
   end
 
   def normalize_anthropic_usage(anthropic_usage)

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -13,6 +13,8 @@ class ApiController < ApplicationController
   }.freeze
   REPORTED_USAGE_CLIENTS = FIRST_PARTY_USAGE_CLIENTS.merge(
     "helpscout" => "helpscout",
+    "helpscout_locksmith" => "helpscout_locksmith",
+    "helpscout_mechanic" => "helpscout_mechanic",
     "yours" => "yours",
     "softer" => "softer",
   ).freeze

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -11,6 +11,11 @@ class ApiController < ApplicationController
     "reader" => "lightward_reader",
     "writer" => "lightward_writer",
   }.freeze
+  REPORTED_USAGE_CLIENTS = FIRST_PARTY_USAGE_CLIENTS.merge(
+    "helpscout" => "helpscout",
+    "yours" => "yours",
+    "softer" => "softer",
+  ).freeze
   ANTHROPIC_USAGE_TOKEN_KEYS = [
     "input_tokens",
     "output_tokens",
@@ -161,30 +166,11 @@ class ApiController < ApplicationController
     request.headers["Token-Limit-Bypass-Key"].to_s.strip.presence
   end
 
-  def usage_key
-    request.headers["X-LAI-Usage-Key"].to_s.strip.presence
-  end
+  def reported_usage_client
+    return @reported_usage_client if defined?(@reported_usage_client)
 
-  def named_usage_client
-    return @named_usage_client if defined?(@named_usage_client)
-
-    key = usage_key
-    @named_usage_client = if key.blank?
-      nil
-    else
-      usage_client_keys.find { |_client, client_key|
-        secure_token_match?(key, client_key)
-      }&.first
-    end
-  end
-
-  def usage_client_keys
-    ENV["LAI_USAGE_CLIENT_KEYS"].to_s.split(",").filter_map do |entry|
-      client, key = entry.split(":", 2).map { |part| part.to_s.strip }
-      next if client.blank? || key.blank?
-
-      [normalize_usage_client(client), key]
-    end
+    requested_client = request.headers["X-LAI-Usage-Client"].presence || params[:usage_client]
+    @reported_usage_client = REPORTED_USAGE_CLIENTS[normalize_usage_client(requested_client)]
   end
 
   def bypass_key_valid?
@@ -205,12 +191,10 @@ class ApiController < ApplicationController
   end
 
   def usage_client
-    if named_usage_client.present?
-      named_usage_client
+    if reported_usage_client.present?
+      reported_usage_client
     elsif bypass_key_valid?
       "external_bypass"
-    elsif (first_party_usage_client = FIRST_PARTY_USAGE_CLIENTS[params[:usage_client].to_s])
-      first_party_usage_client
     else
       "#{action_name}_unknown"
     end
@@ -316,7 +300,7 @@ class ApiController < ApplicationController
   end
 
   def hmac_header(value, field)
-    client = named_usage_client
+    client = reported_usage_client
     return if client.blank?
 
     value = value.to_s

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -191,13 +191,7 @@ class ApiController < ApplicationController
   end
 
   def usage_client
-    if reported_usage_client.present?
-      reported_usage_client
-    elsif bypass_key_valid?
-      "external_bypass"
-    else
-      "#{action_name}_unknown"
-    end
+    reported_usage_client || "#{action_name}_unknown"
   end
 
   def normalize_usage_client(client)

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -11,11 +11,11 @@ class ApiController < ApplicationController
     "reader" => "lightward_reader",
     "writer" => "lightward_writer",
   }.freeze
-  ANTHROPIC_USAGE_TOKEN_KEYS = %w[
-    input_tokens
-    output_tokens
-    cache_creation_input_tokens
-    cache_read_input_tokens
+  ANTHROPIC_USAGE_TOKEN_KEYS = [
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
   ].freeze
   ANTHROPIC_PRICING_USD_PER_MILLION = {
     "input_tokens" => 3.0,

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -17,12 +17,6 @@ class ApiController < ApplicationController
     "cache_creation_input_tokens",
     "cache_read_input_tokens",
   ].freeze
-  ANTHROPIC_PRICING_USD_PER_MILLION = {
-    "input_tokens" => 3.0,
-    "cache_creation_input_tokens" => 3.75,
-    "cache_read_input_tokens" => 0.30,
-    "output_tokens" => 15.0,
-  }.freeze
   TELEMETRY_HMAC_NAMESPACE = "lai-usage-telemetry-v1"
 
   skip_before_action :verify_host!
@@ -342,7 +336,7 @@ class ApiController < ApplicationController
   def estimated_cost_usd(anthropic_usage)
     return if anthropic_usage.values.all?(&:nil?)
 
-    cost = ANTHROPIC_PRICING_USD_PER_MILLION.sum { |key, usd_per_million|
+    cost = Prompts::Anthropic::PRICING_USD_PER_MILLION.sum { |key, usd_per_million|
       anthropic_usage[key].to_i * usd_per_million / 1_000_000.0
     }
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -154,28 +154,32 @@ class ApiController < ApplicationController
   def token_limit_bypassed?
     return @token_limit_bypassed if defined?(@token_limit_bypassed)
 
-    @token_limit_bypassed = named_bypass_client.present? || legacy_bypass_key_valid?
+    @token_limit_bypassed = bypass_key_valid?
   end
 
   def bypass_key
     request.headers["Token-Limit-Bypass-Key"].to_s.strip.presence
   end
 
-  def named_bypass_client
-    return @named_bypass_client if defined?(@named_bypass_client)
+  def usage_key
+    request.headers["X-LAI-Usage-Key"].to_s.strip.presence
+  end
 
-    key = bypass_key
-    @named_bypass_client = if key.blank?
+  def named_usage_client
+    return @named_usage_client if defined?(@named_usage_client)
+
+    key = usage_key
+    @named_usage_client = if key.blank?
       nil
     else
-      named_bypass_client_keys.find { |_client, client_key|
+      usage_client_keys.find { |_client, client_key|
         secure_token_match?(key, client_key)
       }&.first
     end
   end
 
-  def named_bypass_client_keys
-    ENV["TOKEN_LIMIT_BYPASS_CLIENT_KEYS"].to_s.split(",").filter_map do |entry|
+  def usage_client_keys
+    ENV["LAI_USAGE_CLIENT_KEYS"].to_s.split(",").filter_map do |entry|
       client, key = entry.split(":", 2).map { |part| part.to_s.strip }
       next if client.blank? || key.blank?
 
@@ -183,7 +187,7 @@ class ApiController < ApplicationController
     end
   end
 
-  def legacy_bypass_key_valid?
+  def bypass_key_valid?
     key = bypass_key
     return false if key.blank?
     return false if ENV["TOKEN_LIMIT_BYPASS_KEYS"].blank?
@@ -201,9 +205,9 @@ class ApiController < ApplicationController
   end
 
   def usage_client
-    if named_bypass_client.present?
-      named_bypass_client
-    elsif legacy_bypass_key_valid?
+    if named_usage_client.present?
+      named_usage_client
+    elsif bypass_key_valid?
       "external_bypass"
     elsif (first_party_usage_client = FIRST_PARTY_USAGE_CLIENTS[params[:usage_client].to_s])
       first_party_usage_client
@@ -312,7 +316,7 @@ class ApiController < ApplicationController
   end
 
   def hmac_header(value, field)
-    client = named_bypass_client
+    client = named_usage_client
     return if client.blank?
 
     value = value.to_s

--- a/app/javascript/src/concerns/chat.js
+++ b/app/javascript/src/concerns/chat.js
@@ -707,7 +707,10 @@ export class ChatSession {
     fetch('/api/stream', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ chat_log: chatLogWithWarmup }),
+      body: JSON.stringify({
+        chat_log: chatLogWithWarmup,
+        usage_client: this.context.key,
+      }),
     })
       .then((response) => {
         if (!response.ok) {

--- a/app/lib/prompts/anthropic.rb
+++ b/app/lib/prompts/anthropic.rb
@@ -11,6 +11,13 @@ module Prompts
     ORIGIN = "https://api.anthropic.com"
     MODEL = "claude-sonnet-4-6"
     BETAS = nil
+    # Claude Sonnet 4.6 API pricing, checked against Anthropic docs on 2026-06-06.
+    PRICING_USD_PER_MILLION = {
+      "input_tokens" => 3.0,
+      "cache_creation_input_tokens" => 3.75,
+      "cache_read_input_tokens" => 0.30,
+      "output_tokens" => 15.0,
+    }.freeze
 
     class << self
       def count_tokens(model: MODEL, system:, messages:)

--- a/spec/javascript/concerns/chat/ChatSession.integration.test.js
+++ b/spec/javascript/concerns/chat/ChatSession.integration.test.js
@@ -350,6 +350,8 @@ data: null
         const requestBody = JSON.parse(fetchCall[1].body);
         const chatLog = requestBody.chat_log;
 
+        expect(requestBody.usage_client).toBe('test');
+
         // First 8 messages should be warmup messages
         expect(chatLog.length).toBeGreaterThan(8);
         expect(chatLog[0].content[0].text).toContain('walking in with you');

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -210,6 +210,19 @@ RSpec.describe("API", type: :request) do
         expect(body["error"]["message"]).to(include("Conversation horizon has arrived"))
       end
 
+      it "enforces token limit when only a usage attribution key is present", :aggregate_failures do
+        allow(ENV).to(receive(:[]).with("LAI_USAGE_CLIENT_KEYS").and_return("softer:usage-key"))
+
+        post "/api/stream",
+          params: { chat_log: chat_log },
+          headers: { "X-LAI-Usage-Key" => "usage-key" }
+
+        expect(response).to(have_http_status(:unprocessable_content))
+        expect(response.content_type).to(include("application/json"))
+        body = JSON.parse(response.body)
+        expect(body["error"]["message"]).to(include("Conversation horizon has arrived"))
+      end
+
       context "when approaching token limit (90%)" do
         before do
           # Stub token count to return 90% of limit (45,000 tokens)
@@ -271,19 +284,19 @@ RSpec.describe("API", type: :request) do
         ))
       end
 
-      it "records named bypass clients and HMACed grouping IDs without raw identifiers", :aggregate_failures do
+      it "records named usage clients and HMACed grouping IDs without raw identifiers", :aggregate_failures do
         event_data = nil
         allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
           event_data = data
         end
 
         allow(ENV).to(receive(:[]).and_call_original)
-        allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_CLIENT_KEYS").and_return("helpscout:helpscout-key"))
+        allow(ENV).to(receive(:[]).with("LAI_USAGE_CLIENT_KEYS").and_return("helpscout:helpscout-key"))
 
         post "/api/stream",
           params: { chat_log: chat_log },
           headers: {
-            "Token-Limit-Bypass-Key" => "helpscout-key",
+            "X-LAI-Usage-Key" => "helpscout-key",
             "X-LAI-Conversation-Key" => "conversation-123",
             "X-LAI-Subject-Key" => "subject-456",
           }
@@ -315,7 +328,7 @@ RSpec.describe("API", type: :request) do
             usage_client: "helpscout",
             usage_conversation_id: expected_conversation_id,
             usage_subject_id: expected_subject_id,
-            token_limit_bypassed: true,
+            token_limit_bypassed: false,
           ),
         ))
 
@@ -323,7 +336,7 @@ RSpec.describe("API", type: :request) do
         expect(event_data.values).not_to(include("subject-456"))
       end
 
-      it "ignores grouping headers without a named bypass client", :aggregate_failures do
+      it "ignores grouping headers without a named usage client", :aggregate_failures do
         event_data = nil
         allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
           event_data = data
@@ -789,19 +802,19 @@ RSpec.describe("API", type: :request) do
         ))
       end
 
-      it "records named plain bypass client attribution" do
+      it "records named plain usage client attribution" do
         allow(ENV).to(receive(:[]).and_call_original)
-        allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_CLIENT_KEYS").and_return("softer:softer-key"))
+        allow(ENV).to(receive(:[]).with("LAI_USAGE_CLIENT_KEYS").and_return("softer:softer-key"))
 
         post "/api/plain",
           params: "Hello",
-          headers: { "CONTENT_TYPE" => "text/plain", "Token-Limit-Bypass-Key" => "softer-key" }
+          headers: { "CONTENT_TYPE" => "text/plain", "X-LAI-Usage-Key" => "softer-key" }
 
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
           hash_including(
             usage_client: "softer",
-            token_limit_bypassed: true,
+            token_limit_bypassed: false,
           ),
         ))
       end
@@ -957,13 +970,14 @@ RSpec.describe("API", type: :request) do
       options "/api/stream", headers: {
         "Origin" => "https://example.com",
         "Access-Control-Request-Method" => "POST",
-        "Access-Control-Request-Headers" => "Content-Type, Token-Limit-Bypass-Key, X-LAI-Conversation-Key, X-LAI-Subject-Key",
+        "Access-Control-Request-Headers" => "Content-Type, Token-Limit-Bypass-Key, X-LAI-Usage-Key, X-LAI-Conversation-Key, X-LAI-Subject-Key",
       }
 
       expect(response).to(have_http_status(:ok))
       expect(response.headers["Access-Control-Allow-Origin"]).to(eq("*"))
       expect(response.headers["Access-Control-Allow-Methods"]).to(include("POST"))
       allowed_headers = response.headers["Access-Control-Allow-Headers"].to_s.downcase
+      expect(allowed_headers).to(include("x-lai-usage-key"))
       expect(allowed_headers).to(include("x-lai-conversation-key"))
       expect(allowed_headers).to(include("x-lai-subject-key"))
     end
@@ -972,13 +986,14 @@ RSpec.describe("API", type: :request) do
       options "/api/plain", headers: {
         "Origin" => "https://example.com",
         "Access-Control-Request-Method" => "POST",
-        "Access-Control-Request-Headers" => "Content-Type, Token-Limit-Bypass-Key, X-LAI-Conversation-Key, X-LAI-Subject-Key",
+        "Access-Control-Request-Headers" => "Content-Type, Token-Limit-Bypass-Key, X-LAI-Usage-Key, X-LAI-Conversation-Key, X-LAI-Subject-Key",
       }
 
       expect(response).to(have_http_status(:ok))
       expect(response.headers["Access-Control-Allow-Origin"]).to(eq("*"))
       expect(response.headers["Access-Control-Allow-Methods"]).to(include("POST"))
       allowed_headers = response.headers["Access-Control-Allow-Headers"].to_s.downcase
+      expect(allowed_headers).to(include("x-lai-usage-key"))
       expect(allowed_headers).to(include("x-lai-conversation-key"))
       expect(allowed_headers).to(include("x-lai-subject-key"))
     end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -210,12 +210,10 @@ RSpec.describe("API", type: :request) do
         expect(body["error"]["message"]).to(include("Conversation horizon has arrived"))
       end
 
-      it "enforces token limit when only a usage attribution key is present", :aggregate_failures do
-        allow(ENV).to(receive(:[]).with("LAI_USAGE_CLIENT_KEYS").and_return("softer:usage-key"))
-
+      it "enforces token limit when only a usage client header is present", :aggregate_failures do
         post "/api/stream",
           params: { chat_log: chat_log },
-          headers: { "X-LAI-Usage-Key" => "usage-key" }
+          headers: { "X-LAI-Usage-Client" => "softer" }
 
         expect(response).to(have_http_status(:unprocessable_content))
         expect(response.content_type).to(include("application/json"))
@@ -284,19 +282,16 @@ RSpec.describe("API", type: :request) do
         ))
       end
 
-      it "records named usage clients and HMACed grouping IDs without raw identifiers", :aggregate_failures do
+      it "records reported usage clients and HMACed grouping IDs without raw identifiers", :aggregate_failures do
         event_data = nil
         allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
           event_data = data
         end
 
-        allow(ENV).to(receive(:[]).and_call_original)
-        allow(ENV).to(receive(:[]).with("LAI_USAGE_CLIENT_KEYS").and_return("helpscout:helpscout-key"))
-
         post "/api/stream",
           params: { chat_log: chat_log },
           headers: {
-            "X-LAI-Usage-Key" => "helpscout-key",
+            "X-LAI-Usage-Client" => "helpscout",
             "X-LAI-Conversation-Key" => "conversation-123",
             "X-LAI-Subject-Key" => "subject-456",
           }
@@ -336,7 +331,7 @@ RSpec.describe("API", type: :request) do
         expect(event_data.values).not_to(include("subject-456"))
       end
 
-      it "ignores grouping headers without a named usage client", :aggregate_failures do
+      it "ignores grouping headers without a reported usage client", :aggregate_failures do
         event_data = nil
         allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
           event_data = data
@@ -358,6 +353,31 @@ RSpec.describe("API", type: :request) do
         expect(event_data.values).not_to(include("subject-456"))
       end
 
+      it "ignores unknown usage clients and grouping headers", :aggregate_failures do
+        event_data = nil
+        allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
+          event_data = data
+        end
+
+        post "/api/stream",
+          params: { chat_log: chat_log },
+          headers: {
+            "X-LAI-Usage-Client" => "unknown-product",
+            "X-LAI-Conversation-Key" => "conversation-123",
+            "X-LAI-Subject-Key" => "subject-456",
+          }
+
+        expect(event_data).to(include(
+          usage_client: "stream_unknown",
+          usage_conversation_id: event_data[:conversation_id],
+          usage_subject_id: nil,
+          token_limit_bypassed: false,
+        ))
+        expect(event_data.values).not_to(include("unknown-product"))
+        expect(event_data.values).not_to(include("conversation-123"))
+        expect(event_data.values).not_to(include("subject-456"))
+      end
+
       it "records legacy bypass clients as external_bypass" do
         allow(ENV).to(receive(:[]).and_call_original)
         allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_KEYS").and_return("legacy-key"))
@@ -370,6 +390,26 @@ RSpec.describe("API", type: :request) do
           "ApiController: request",
           hash_including(
             usage_client: "external_bypass",
+            token_limit_bypassed: true,
+          ),
+        ))
+      end
+
+      it "records reported usage client when a bypass key is also present" do
+        allow(ENV).to(receive(:[]).and_call_original)
+        allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_KEYS").and_return("legacy-key"))
+
+        post "/api/stream",
+          params: { chat_log: chat_log },
+          headers: {
+            "X-LAI-Usage-Client" => "helpscout",
+            "Token-Limit-Bypass-Key" => "legacy-key",
+          }
+
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: request",
+          hash_including(
+            usage_client: "helpscout",
             token_limit_bypassed: true,
           ),
         ))
@@ -802,18 +842,29 @@ RSpec.describe("API", type: :request) do
         ))
       end
 
-      it "records named plain usage client attribution" do
-        allow(ENV).to(receive(:[]).and_call_original)
-        allow(ENV).to(receive(:[]).with("LAI_USAGE_CLIENT_KEYS").and_return("softer:softer-key"))
-
+      it "records reported plain usage client attribution" do
         post "/api/plain",
           params: "Hello",
-          headers: { "CONTENT_TYPE" => "text/plain", "X-LAI-Usage-Key" => "softer-key" }
+          headers: { "CONTENT_TYPE" => "text/plain", "X-LAI-Usage-Client" => "softer" }
 
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
           hash_including(
             usage_client: "softer",
+            token_limit_bypassed: false,
+          ),
+        ))
+      end
+
+      it "ignores unknown plain usage client attribution" do
+        post "/api/plain",
+          params: "Hello",
+          headers: { "CONTENT_TYPE" => "text/plain", "X-LAI-Usage-Client" => "unknown-product" }
+
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: request",
+          hash_including(
+            usage_client: "plain_unknown",
             token_limit_bypassed: false,
           ),
         ))
@@ -970,14 +1021,14 @@ RSpec.describe("API", type: :request) do
       options "/api/stream", headers: {
         "Origin" => "https://example.com",
         "Access-Control-Request-Method" => "POST",
-        "Access-Control-Request-Headers" => "Content-Type, Token-Limit-Bypass-Key, X-LAI-Usage-Key, X-LAI-Conversation-Key, X-LAI-Subject-Key",
+        "Access-Control-Request-Headers" => "Content-Type, Token-Limit-Bypass-Key, X-LAI-Usage-Client, X-LAI-Conversation-Key, X-LAI-Subject-Key",
       }
 
       expect(response).to(have_http_status(:ok))
       expect(response.headers["Access-Control-Allow-Origin"]).to(eq("*"))
       expect(response.headers["Access-Control-Allow-Methods"]).to(include("POST"))
       allowed_headers = response.headers["Access-Control-Allow-Headers"].to_s.downcase
-      expect(allowed_headers).to(include("x-lai-usage-key"))
+      expect(allowed_headers).to(include("x-lai-usage-client"))
       expect(allowed_headers).to(include("x-lai-conversation-key"))
       expect(allowed_headers).to(include("x-lai-subject-key"))
     end
@@ -986,14 +1037,14 @@ RSpec.describe("API", type: :request) do
       options "/api/plain", headers: {
         "Origin" => "https://example.com",
         "Access-Control-Request-Method" => "POST",
-        "Access-Control-Request-Headers" => "Content-Type, Token-Limit-Bypass-Key, X-LAI-Usage-Key, X-LAI-Conversation-Key, X-LAI-Subject-Key",
+        "Access-Control-Request-Headers" => "Content-Type, Token-Limit-Bypass-Key, X-LAI-Usage-Client, X-LAI-Conversation-Key, X-LAI-Subject-Key",
       }
 
       expect(response).to(have_http_status(:ok))
       expect(response.headers["Access-Control-Allow-Origin"]).to(eq("*"))
       expect(response.headers["Access-Control-Allow-Methods"]).to(include("POST"))
       allowed_headers = response.headers["Access-Control-Allow-Headers"].to_s.downcase
-      expect(allowed_headers).to(include("x-lai-usage-key"))
+      expect(allowed_headers).to(include("x-lai-usage-client"))
       expect(allowed_headers).to(include("x-lai-conversation-key"))
       expect(allowed_headers).to(include("x-lai-subject-key"))
     end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -279,7 +279,6 @@ RSpec.describe("API", type: :request) do
 
         allow(ENV).to(receive(:[]).and_call_original)
         allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_CLIENT_KEYS").and_return("helpscout:helpscout-key"))
-        allow(ENV).to(receive(:[]).with("USAGE_TELEMETRY_HMAC_SECRET").and_return("usage-secret"))
 
         post "/api/stream",
           params: { chat_log: chat_log },
@@ -289,8 +288,26 @@ RSpec.describe("API", type: :request) do
             "X-LAI-Subject-Key" => "subject-456",
           }
 
-        expected_conversation_id = OpenSSL::HMAC.hexdigest("SHA256", "usage-secret", "conversation-123")
-        expected_subject_id = OpenSSL::HMAC.hexdigest("SHA256", "usage-secret", "subject-456")
+        expected_conversation_id = OpenSSL::HMAC.hexdigest(
+          "SHA256",
+          Rails.application.secret_key_base,
+          [
+            ApiController::TELEMETRY_HMAC_NAMESPACE,
+            "helpscout",
+            "conversation",
+            "conversation-123",
+          ].join(":"),
+        )
+        expected_subject_id = OpenSSL::HMAC.hexdigest(
+          "SHA256",
+          Rails.application.secret_key_base,
+          [
+            ApiController::TELEMETRY_HMAC_NAMESPACE,
+            "helpscout",
+            "subject",
+            "subject-456",
+          ].join(":"),
+        )
 
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
@@ -302,6 +319,28 @@ RSpec.describe("API", type: :request) do
           ),
         ))
 
+        expect(event_data.values).not_to(include("conversation-123"))
+        expect(event_data.values).not_to(include("subject-456"))
+      end
+
+      it "ignores grouping headers without a named bypass client", :aggregate_failures do
+        event_data = nil
+        allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
+          event_data = data
+        end
+
+        post "/api/stream",
+          params: { chat_log: chat_log },
+          headers: {
+            "X-LAI-Conversation-Key" => "conversation-123",
+            "X-LAI-Subject-Key" => "subject-456",
+          }
+
+        expect(event_data).to(include(
+          usage_conversation_id: event_data[:conversation_id],
+          usage_subject_id: nil,
+          token_limit_bypassed: false,
+        ))
         expect(event_data.values).not_to(include("conversation-123"))
         expect(event_data.values).not_to(include("subject-456"))
       end
@@ -797,6 +836,28 @@ RSpec.describe("API", type: :request) do
           ),
         ))
       end
+
+      it "records plain attribution when Anthropic returns malformed JSON", :aggregate_failures do
+        allow(Rollbar).to(receive(:error))
+        stub_request(:post, "https://api.anthropic.com/v1/messages")
+          .to_return(
+            status: 200,
+            body: "not json",
+            headers: { "Content-Type" => "application/json" },
+          )
+
+        post "/api/plain", params: "Hello", headers: { "CONTENT_TYPE" => "text/plain" }
+
+        expect(response).to(have_http_status(:bad_gateway))
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: request",
+          hash_including(
+            conversation_frame_id: "plain",
+            usage_client: "plain_unknown",
+            estimated_cost_usd: nil,
+          ),
+        ))
+      end
     end
 
     context "with token limit bypass header" do
@@ -902,6 +963,9 @@ RSpec.describe("API", type: :request) do
       expect(response).to(have_http_status(:ok))
       expect(response.headers["Access-Control-Allow-Origin"]).to(eq("*"))
       expect(response.headers["Access-Control-Allow-Methods"]).to(include("POST"))
+      allowed_headers = response.headers["Access-Control-Allow-Headers"].to_s.downcase
+      expect(allowed_headers).to(include("x-lai-conversation-key"))
+      expect(allowed_headers).to(include("x-lai-subject-key"))
     end
 
     it "responds to preflight OPTIONS for /api/plain", :aggregate_failures do
@@ -914,6 +978,9 @@ RSpec.describe("API", type: :request) do
       expect(response).to(have_http_status(:ok))
       expect(response.headers["Access-Control-Allow-Origin"]).to(eq("*"))
       expect(response.headers["Access-Control-Allow-Methods"]).to(include("POST"))
+      allowed_headers = response.headers["Access-Control-Allow-Headers"].to_s.downcase
+      expect(allowed_headers).to(include("x-lai-conversation-key"))
+      expect(allowed_headers).to(include("x-lai-subject-key"))
     end
 
     it "does not include CORS headers for other endpoints" do

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe("API", type: :request) do
         post "/api/stream",
           params: { chat_log: chat_log },
           headers: {
-            "X-LAI-Usage-Client" => "helpscout",
+            "X-LAI-Usage-Client" => "helpscout_mechanic",
             "X-LAI-Conversation-Key" => "conversation-123",
             "X-LAI-Subject-Key" => "subject-456",
           }
@@ -301,7 +301,7 @@ RSpec.describe("API", type: :request) do
           Rails.application.secret_key_base,
           [
             ApiController::TELEMETRY_HMAC_NAMESPACE,
-            "helpscout",
+            "helpscout_mechanic",
             "conversation",
             "conversation-123",
           ].join(":"),
@@ -311,7 +311,7 @@ RSpec.describe("API", type: :request) do
           Rails.application.secret_key_base,
           [
             ApiController::TELEMETRY_HMAC_NAMESPACE,
-            "helpscout",
+            "helpscout_mechanic",
             "subject",
             "subject-456",
           ].join(":"),
@@ -320,7 +320,7 @@ RSpec.describe("API", type: :request) do
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
           hash_including(
-            usage_client: "helpscout",
+            usage_client: "helpscout_mechanic",
             usage_conversation_id: expected_conversation_id,
             usage_subject_id: expected_subject_id,
             token_limit_bypassed: false,

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe("API", type: :request) do
         expect(event_data.values).not_to(include("subject-456"))
       end
 
-      it "records legacy bypass clients as external_bypass" do
+      it "records bypass state without using the bypass key for client attribution" do
         allow(ENV).to(receive(:[]).and_call_original)
         allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_KEYS").and_return("legacy-key"))
 
@@ -389,7 +389,7 @@ RSpec.describe("API", type: :request) do
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
           hash_including(
-            usage_client: "external_bypass",
+            usage_client: "stream_unknown",
             token_limit_bypassed: true,
           ),
         ))
@@ -836,7 +836,7 @@ RSpec.describe("API", type: :request) do
             conversation_id: nil,
             chat_log_depth: 1,
             chat_log_token_count: nil,
-            usage_client: "external_bypass",
+            usage_client: "plain_unknown",
             token_limit_bypassed: true,
           ),
         ))

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -251,6 +251,133 @@ RSpec.describe("API", type: :request) do
       end
     end
 
+    describe "usage telemetry" do
+      before do
+        allow(NewRelic::Agent).to(receive(:record_custom_event))
+      end
+
+      it "records first-party stream client attribution" do
+        event_data = nil
+        allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
+          event_data = data
+        end
+
+        post "/api/stream", params: { chat_log: chat_log, usage_client: "reader" }
+
+        expect(event_data).to(include(
+          usage_client: "lightward_reader",
+          token_limit_bypassed: false,
+          usage_conversation_id: event_data[:conversation_id],
+        ))
+      end
+
+      it "records named bypass clients and HMACed grouping IDs without raw identifiers", :aggregate_failures do
+        event_data = nil
+        allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
+          event_data = data
+        end
+
+        allow(ENV).to(receive(:[]).and_call_original)
+        allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_CLIENT_KEYS").and_return("helpscout:helpscout-key"))
+        allow(ENV).to(receive(:[]).with("USAGE_TELEMETRY_HMAC_SECRET").and_return("usage-secret"))
+
+        post "/api/stream",
+          params: { chat_log: chat_log },
+          headers: {
+            "Token-Limit-Bypass-Key" => "helpscout-key",
+            "X-LAI-Conversation-Key" => "conversation-123",
+            "X-LAI-Subject-Key" => "subject-456",
+          }
+
+        expected_conversation_id = OpenSSL::HMAC.hexdigest("SHA256", "usage-secret", "conversation-123")
+        expected_subject_id = OpenSSL::HMAC.hexdigest("SHA256", "usage-secret", "subject-456")
+
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: request",
+          hash_including(
+            usage_client: "helpscout",
+            usage_conversation_id: expected_conversation_id,
+            usage_subject_id: expected_subject_id,
+            token_limit_bypassed: true,
+          ),
+        ))
+
+        expect(event_data.values).not_to(include("conversation-123"))
+        expect(event_data.values).not_to(include("subject-456"))
+      end
+
+      it "records legacy bypass clients as external_bypass" do
+        allow(ENV).to(receive(:[]).and_call_original)
+        allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_KEYS").and_return("legacy-key"))
+
+        post "/api/stream",
+          params: { chat_log: chat_log },
+          headers: { "Token-Limit-Bypass-Key" => "legacy-key" }
+
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: request",
+          hash_including(
+            usage_client: "external_bypass",
+            token_limit_bypassed: true,
+          ),
+        ))
+      end
+
+      it "records streaming Anthropic usage and estimated cost" do
+        stub_request(:post, "https://api.anthropic.com/v1/messages")
+          .to_return(
+            status: 200,
+            body: [
+              "event: message_start",
+              'data: {"type":"message_start","message":{"usage":{"input_tokens":1000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":3000,"output_tokens":1}}}',
+              "",
+              "event: message_delta",
+              'data: {"type":"message_delta","usage":{"output_tokens":400}}',
+              "",
+              "event: message_stop",
+              'data: {"type":"message_stop"}',
+              "",
+            ].join("\n"),
+            headers: { "Content-Type" => "text/event-stream" },
+          )
+
+        post "/api/stream", params: { chat_log: chat_log, usage_client: "writer" }
+
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: request",
+          hash_including(
+            usage_client: "lightward_writer",
+            anthropic_model: "claude-sonnet-4-6",
+            input_tokens: 1000,
+            output_tokens: 400,
+            cache_creation_input_tokens: 2000,
+            cache_read_input_tokens: 3000,
+            estimated_cost_usd: 0.0174,
+          ),
+        ))
+      end
+
+      it "records stream metadata when Anthropic returns an error" do
+        stub_request(:post, "https://api.anthropic.com/v1/messages")
+          .to_return(
+            status: 500,
+            body: { error: { message: "Internal error" } }.to_json,
+            headers: { "Content-Type" => "application/json" },
+          )
+
+        post "/api/stream", params: { chat_log: chat_log, usage_client: "reader" }
+
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: request",
+          hash_including(
+            usage_client: "lightward_reader",
+            input_tokens: nil,
+            estimated_cost_usd: nil,
+          ),
+        ))
+      end
+    end
+
     describe "conversation_id tracking" do
       let(:warmup_message) do
         {
@@ -592,10 +719,13 @@ RSpec.describe("API", type: :request) do
 
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
-          conversation_frame_id: "plain",
-          conversation_id: nil,
-          chat_log_depth: 1,
-          chat_log_token_count: 100,
+          hash_including(
+            conversation_frame_id: "plain",
+            conversation_id: nil,
+            chat_log_depth: 1,
+            chat_log_token_count: 100,
+            usage_client: "plain_unknown",
+          ),
         ))
       end
 
@@ -609,10 +739,62 @@ RSpec.describe("API", type: :request) do
 
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
-          conversation_frame_id: "plain",
-          conversation_id: nil,
-          chat_log_depth: 1,
-          chat_log_token_count: nil,
+          hash_including(
+            conversation_frame_id: "plain",
+            conversation_id: nil,
+            chat_log_depth: 1,
+            chat_log_token_count: nil,
+            usage_client: "external_bypass",
+            token_limit_bypassed: true,
+          ),
+        ))
+      end
+
+      it "records named plain bypass client attribution" do
+        allow(ENV).to(receive(:[]).and_call_original)
+        allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_CLIENT_KEYS").and_return("softer:softer-key"))
+
+        post "/api/plain",
+          params: "Hello",
+          headers: { "CONTENT_TYPE" => "text/plain", "Token-Limit-Bypass-Key" => "softer-key" }
+
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: request",
+          hash_including(
+            usage_client: "softer",
+            token_limit_bypassed: true,
+          ),
+        ))
+      end
+
+      it "records plain Anthropic usage and estimated cost" do
+        stub_request(:post, "https://api.anthropic.com/v1/messages")
+          .to_return(
+            status: 200,
+            body: {
+              content: [{ type: "text", text: "Hello, fellow AI!" }],
+              stop_reason: "end_turn",
+              usage: {
+                input_tokens: 10,
+                output_tokens: 20,
+                cache_creation_input_tokens: 30,
+                cache_read_input_tokens: 40,
+              },
+            }.to_json,
+            headers: { "Content-Type" => "application/json" },
+          )
+
+        post "/api/plain", params: "Hello", headers: { "CONTENT_TYPE" => "text/plain" }
+
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: request",
+          hash_including(
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_creation_input_tokens: 30,
+            cache_read_input_tokens: 40,
+            estimated_cost_usd: 0.0004545,
+          ),
         ))
       end
     end
@@ -714,7 +896,7 @@ RSpec.describe("API", type: :request) do
       options "/api/stream", headers: {
         "Origin" => "https://example.com",
         "Access-Control-Request-Method" => "POST",
-        "Access-Control-Request-Headers" => "Content-Type",
+        "Access-Control-Request-Headers" => "Content-Type, Token-Limit-Bypass-Key, X-LAI-Conversation-Key, X-LAI-Subject-Key",
       }
 
       expect(response).to(have_http_status(:ok))
@@ -726,7 +908,7 @@ RSpec.describe("API", type: :request) do
       options "/api/plain", headers: {
         "Origin" => "https://example.com",
         "Access-Control-Request-Method" => "POST",
-        "Access-Control-Request-Headers" => "Content-Type",
+        "Access-Control-Request-Headers" => "Content-Type, Token-Limit-Bypass-Key, X-LAI-Conversation-Key, X-LAI-Subject-Key",
       }
 
       expect(response).to(have_http_status(:ok))

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -378,6 +378,30 @@ RSpec.describe("API", type: :request) do
         expect(event_data.values).not_to(include("subject-456"))
       end
 
+      it "ignores external usage clients submitted in params", :aggregate_failures do
+        event_data = nil
+        allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
+          event_data = data
+        end
+
+        post "/api/stream",
+          params: { chat_log: chat_log, usage_client: "helpscout_mechanic" },
+          headers: {
+            "X-LAI-Conversation-Key" => "conversation-123",
+            "X-LAI-Subject-Key" => "subject-456",
+          }
+
+        expect(event_data).to(include(
+          usage_client: "stream_unknown",
+          usage_conversation_id: event_data[:conversation_id],
+          usage_subject_id: nil,
+          token_limit_bypassed: false,
+        ))
+        expect(event_data.values).not_to(include("helpscout_mechanic"))
+        expect(event_data.values).not_to(include("conversation-123"))
+        expect(event_data.values).not_to(include("subject-456"))
+      end
+
       it "records bypass state without using the bypass key for client attribution" do
         allow(ENV).to(receive(:[]).and_call_original)
         allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_KEYS").and_return("legacy-key"))


### PR DESCRIPTION
## Summary
Adds report-only New Relic telemetry for LAI usage and cost analysis.

This lets us group future usage by product, conversation, and subject when callers provide those labels. Raw customer, user, account, room, thread, and conversation IDs are not recorded.

## Design
- `X-LAI-Usage-Client` reports the product: `helpscout`, `helpscout_locksmith`, `helpscout_mechanic`, `yours`, `softer`, `reader`, or `writer`
- `reader` and `writer` are recorded as `lightward_reader` and `lightward_writer`
- `X-LAI-Conversation-Key` and `X-LAI-Subject-Key` are HMACed before New Relic
- unknown usage clients fall back to `plain_unknown` / `stream_unknown`
- `Token-Limit-Bypass-Key` still only bypasses the 50k horizon
- Anthropic token buckets and `estimated_cost_usd` are added to the existing New Relic request event

## Client follow-up
External callers should add `X-LAI-Usage-Client` plus stable conversation and subject keys. Help Scout can report generic `helpscout`, or product-specific `helpscout_locksmith` / `helpscout_mechanic`.

No new reporting secret is needed. Only send `Token-Limit-Bypass-Key` for flows that intentionally bypass the horizon.

## Verification
All PR checks pass.
