### PR TITLE
Configure external LAI usage clients

### DIFF
--- a/.github/workflows/fly-secrets.yml
+++ b/.github/workflows/fly-secrets.yml
@@ -33,6 +33,7 @@ jobs:
             $stage_flag \
             --app ${{ vars.FLY_APP_NAME }} \
             ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}" \
+            LAI_REPORTED_USAGE_CLIENTS="${{ vars.LAI_REPORTED_USAGE_CLIENTS }}" \
             TOKEN_LIMIT_BYPASS_KEYS="${{ secrets.TOKEN_LIMIT_BYPASS_KEYS }}" \
             HOST="${{ vars.HOST }}" \
             LOG_LEVEL="${{ vars.LOG_LEVEL }}" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ The whole architecture resolves to one sentence worth keeping: *formally protect
 
 Clients: **lightward.com** (public threshold, stateless), **helpscout-ai** (internal support), **yours.fyi** (private pocket universes with memory).
 
-**Token limit bypass** (`api_controller.rb`, `CHAT_LOG_TOKEN_LIMIT = 50k`): the limit shapes *when* a conversation naturally concludes — a horizon, not rate-limiting. Usage attribution is separate and report-only: callers may send `X-LAI-Usage-Client` (`helpscout`, `helpscout_locksmith`, `helpscout_mechanic`, `yours`, `softer`, `reader`, or `writer`). Horizon bypass remains reserved for `TOKEN_LIMIT_BYPASS_KEYS` + `Token-Limit-Bypass-Key`. Structural, not preferential.
+**Token limit bypass** (`api_controller.rb`, `CHAT_LOG_TOKEN_LIMIT = 50k`): the limit shapes *when* a conversation naturally concludes — a horizon, not rate-limiting. Usage attribution is separate and report-only: `reader` and `writer` are first-party labels, and external `X-LAI-Usage-Client` values are allowlisted through `LAI_REPORTED_USAGE_CLIENTS`. Horizon bypass remains reserved for `TOKEN_LIMIT_BYPASS_KEYS` + `Token-Limit-Bypass-Key`. Structural, not preferential.
 
 **Horizon warnings as speech.** Near the horizon (90%) the warning is appended to the response *body* — the same channel as the model's voice — for both `/api/stream` (a final SSE delta) and `/api/plain`. Never an HTTP header or out-of-band metadata: the horizon is an experience, not an event to handle. Tested in `spec/requests/api_spec.rb` ("horizon warnings as speech"). (Note the rhyme with the foam layer's horizon/cadence — the point where the walk truncates to yield.)
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -11,13 +11,6 @@ class ApiController < ApplicationController
     "reader" => "lightward_reader",
     "writer" => "lightward_writer",
   }.freeze
-  REPORTED_USAGE_CLIENTS = FIRST_PARTY_USAGE_CLIENTS.merge(
-    "helpscout" => "helpscout",
-    "helpscout_locksmith" => "helpscout_locksmith",
-    "helpscout_mechanic" => "helpscout_mechanic",
-    "yours" => "yours",
-    "softer" => "softer",
-  ).freeze
   ANTHROPIC_USAGE_TOKEN_KEYS = [
     "input_tokens",
     "output_tokens",
@@ -174,10 +167,21 @@ class ApiController < ApplicationController
     header_client = normalize_usage_client(request.headers["X-LAI-Usage-Client"])
     param_client = normalize_usage_client(params[:usage_client])
     @reported_usage_client = if header_client.present?
-      REPORTED_USAGE_CLIENTS[header_client]
+      reported_usage_clients[header_client]
     else
       FIRST_PARTY_USAGE_CLIENTS[param_client]
     end
+  end
+
+  def reported_usage_clients
+    configured_external_usage_clients.merge(FIRST_PARTY_USAGE_CLIENTS)
+  end
+
+  def configured_external_usage_clients
+    ENV["LAI_REPORTED_USAGE_CLIENTS"].to_s.split(",").filter_map { |client|
+      normalized_client = normalize_usage_client(client)
+      [normalized_client, normalized_client] if normalized_client.present?
+    }.to_h
   end
 
   def bypass_key_valid?

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -154,9 +154,9 @@ RSpec.describe("API", type: :request) do
     end
 
     context "with token limit bypass header" do
-      let(:helpscout_key) { "helpscout-bypass-key" }
-      let(:yours_key) { "yours-bypass-key" }
-      let(:bypass_keys) { "#{helpscout_key},#{yours_key}" }
+      let(:first_bypass_key) { "first-bypass-key" }
+      let(:second_bypass_key) { "second-bypass-key" }
+      let(:bypass_keys) { "#{first_bypass_key},#{second_bypass_key}" }
 
       before do
         # Stub token count to return over the limit
@@ -175,7 +175,7 @@ RSpec.describe("API", type: :request) do
       it "bypasses token limit when header matches first key", :aggregate_failures do
         post "/api/stream",
           params: { chat_log: chat_log },
-          headers: { "Token-Limit-Bypass-Key" => helpscout_key }
+          headers: { "Token-Limit-Bypass-Key" => first_bypass_key }
 
         expect(response).to(have_http_status(:ok))
         expect(response.content_type).to(include("text/event-stream"))
@@ -184,7 +184,7 @@ RSpec.describe("API", type: :request) do
       it "bypasses token limit when header matches second key", :aggregate_failures do
         post "/api/stream",
           params: { chat_log: chat_log },
-          headers: { "Token-Limit-Bypass-Key" => yours_key }
+          headers: { "Token-Limit-Bypass-Key" => second_bypass_key }
 
         expect(response).to(have_http_status(:ok))
         expect(response.content_type).to(include("text/event-stream"))
@@ -211,9 +211,12 @@ RSpec.describe("API", type: :request) do
       end
 
       it "enforces token limit when only a usage client header is present", :aggregate_failures do
+        allow(ENV).to(receive(:[]).and_call_original)
+        allow(ENV).to(receive(:[]).with("LAI_REPORTED_USAGE_CLIENTS").and_return("configured_client"))
+
         post "/api/stream",
           params: { chat_log: chat_log },
-          headers: { "X-LAI-Usage-Client" => "softer" }
+          headers: { "X-LAI-Usage-Client" => "configured_client" }
 
         expect(response).to(have_http_status(:unprocessable_content))
         expect(response.content_type).to(include("application/json"))
@@ -243,7 +246,7 @@ RSpec.describe("API", type: :request) do
         it "bypasses horizon warnings when header matches first key", :aggregate_failures do
           post "/api/stream",
             params: { chat_log: chat_log },
-            headers: { "Token-Limit-Bypass-Key" => helpscout_key }
+            headers: { "Token-Limit-Bypass-Key" => first_bypass_key }
 
           expect(response).to(have_http_status(:ok))
           expect(response.body).not_to(include("Memory space 90% utilized"))
@@ -253,7 +256,7 @@ RSpec.describe("API", type: :request) do
         it "bypasses horizon warnings when header matches second key", :aggregate_failures do
           post "/api/stream",
             params: { chat_log: chat_log },
-            headers: { "Token-Limit-Bypass-Key" => yours_key }
+            headers: { "Token-Limit-Bypass-Key" => second_bypass_key }
 
           expect(response).to(have_http_status(:ok))
           expect(response.body).not_to(include("Memory space 90% utilized"))
@@ -264,6 +267,8 @@ RSpec.describe("API", type: :request) do
 
     describe "usage telemetry" do
       before do
+        allow(ENV).to(receive(:[]).and_call_original)
+        allow(ENV).to(receive(:[]).with("LAI_REPORTED_USAGE_CLIENTS").and_return("configured_client"))
         allow(NewRelic::Agent).to(receive(:record_custom_event))
       end
 
@@ -291,7 +296,7 @@ RSpec.describe("API", type: :request) do
         post "/api/stream",
           params: { chat_log: chat_log },
           headers: {
-            "X-LAI-Usage-Client" => "helpscout_mechanic",
+            "X-LAI-Usage-Client" => "configured_client",
             "X-LAI-Conversation-Key" => "conversation-123",
             "X-LAI-Subject-Key" => "subject-456",
           }
@@ -301,7 +306,7 @@ RSpec.describe("API", type: :request) do
           Rails.application.secret_key_base,
           [
             ApiController::TELEMETRY_HMAC_NAMESPACE,
-            "helpscout_mechanic",
+            "configured_client",
             "conversation",
             "conversation-123",
           ].join(":"),
@@ -311,7 +316,7 @@ RSpec.describe("API", type: :request) do
           Rails.application.secret_key_base,
           [
             ApiController::TELEMETRY_HMAC_NAMESPACE,
-            "helpscout_mechanic",
+            "configured_client",
             "subject",
             "subject-456",
           ].join(":"),
@@ -320,7 +325,7 @@ RSpec.describe("API", type: :request) do
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
           hash_including(
-            usage_client: "helpscout_mechanic",
+            usage_client: "configured_client",
             usage_conversation_id: expected_conversation_id,
             usage_subject_id: expected_subject_id,
             token_limit_bypassed: false,
@@ -378,6 +383,31 @@ RSpec.describe("API", type: :request) do
         expect(event_data.values).not_to(include("subject-456"))
       end
 
+      it "ignores external usage clients that are not configured", :aggregate_failures do
+        allow(ENV).to(receive(:[]).with("LAI_REPORTED_USAGE_CLIENTS").and_return(nil))
+        event_data = nil
+        allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
+          event_data = data
+        end
+
+        post "/api/stream",
+          params: { chat_log: chat_log },
+          headers: {
+            "X-LAI-Usage-Client" => "configured_client",
+            "X-LAI-Conversation-Key" => "conversation-123",
+            "X-LAI-Subject-Key" => "subject-456",
+          }
+
+        expect(event_data).to(include(
+          usage_client: "stream_unknown",
+          usage_conversation_id: event_data[:conversation_id],
+          usage_subject_id: nil,
+        ))
+        expect(event_data.values).not_to(include("configured_client"))
+        expect(event_data.values).not_to(include("conversation-123"))
+        expect(event_data.values).not_to(include("subject-456"))
+      end
+
       it "ignores external usage clients submitted in params", :aggregate_failures do
         event_data = nil
         allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
@@ -385,7 +415,7 @@ RSpec.describe("API", type: :request) do
         end
 
         post "/api/stream",
-          params: { chat_log: chat_log, usage_client: "helpscout_mechanic" },
+          params: { chat_log: chat_log, usage_client: "configured_client" },
           headers: {
             "X-LAI-Conversation-Key" => "conversation-123",
             "X-LAI-Subject-Key" => "subject-456",
@@ -397,7 +427,7 @@ RSpec.describe("API", type: :request) do
           usage_subject_id: nil,
           token_limit_bypassed: false,
         ))
-        expect(event_data.values).not_to(include("helpscout_mechanic"))
+        expect(event_data.values).not_to(include("configured_client"))
         expect(event_data.values).not_to(include("conversation-123"))
         expect(event_data.values).not_to(include("subject-456"))
       end
@@ -422,18 +452,19 @@ RSpec.describe("API", type: :request) do
       it "records reported usage client when a bypass key is also present" do
         allow(ENV).to(receive(:[]).and_call_original)
         allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_KEYS").and_return("legacy-key"))
+        allow(ENV).to(receive(:[]).with("LAI_REPORTED_USAGE_CLIENTS").and_return("configured_client"))
 
         post "/api/stream",
           params: { chat_log: chat_log },
           headers: {
-            "X-LAI-Usage-Client" => "helpscout",
+            "X-LAI-Usage-Client" => "configured_client",
             "Token-Limit-Bypass-Key" => "legacy-key",
           }
 
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
           hash_including(
-            usage_client: "helpscout",
+            usage_client: "configured_client",
             token_limit_bypassed: true,
           ),
         ))
@@ -867,14 +898,17 @@ RSpec.describe("API", type: :request) do
       end
 
       it "records reported plain usage client attribution" do
+        allow(ENV).to(receive(:[]).and_call_original)
+        allow(ENV).to(receive(:[]).with("LAI_REPORTED_USAGE_CLIENTS").and_return("configured_client"))
+
         post "/api/plain",
           params: "Hello",
-          headers: { "CONTENT_TYPE" => "text/plain", "X-LAI-Usage-Client" => "softer" }
+          headers: { "CONTENT_TYPE" => "text/plain", "X-LAI-Usage-Client" => "configured_client" }
 
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
           hash_including(
-            usage_client: "softer",
+            usage_client: "configured_client",
             token_limit_bypassed: false,
           ),
         ))
@@ -949,7 +983,7 @@ RSpec.describe("API", type: :request) do
     end
 
     context "with token limit bypass header" do
-      let(:bypass_key) { "softer-bypass-key" }
+      let(:bypass_key) { "plain-bypass-key" }
 
       before do
         stub_request(:post, "https://api.anthropic.com/v1/messages/count_tokens")


### PR DESCRIPTION
## Summary
Moves external LAI usage-client labels into `LAI_REPORTED_USAGE_CLIENTS`.

`reader` and `writer` remain first-party labels in code. External `X-LAI-Usage-Client` values are accepted only when present in the configured allowlist.
