### PR TITLE
Throttle expensive public LAI usage

### DIFF
--- a/.github/workflows/fly-secrets.yml
+++ b/.github/workflows/fly-secrets.yml
@@ -34,6 +34,9 @@ jobs:
             --app ${{ vars.FLY_APP_NAME }} \
             ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}" \
             LAI_REPORTED_USAGE_CLIENTS="${{ vars.LAI_REPORTED_USAGE_CLIENTS }}" \
+            PUBLIC_USAGE_THROTTLE_MODE="${{ vars.PUBLIC_USAGE_THROTTLE_MODE }}" \
+            PUBLIC_USAGE_THROTTLE_REDIS_URL="${{ secrets.PUBLIC_USAGE_THROTTLE_REDIS_URL }}" \
+            PUBLIC_USAGE_THROTTLE_RULES="${{ secrets.PUBLIC_USAGE_THROTTLE_RULES }}" \
             TOKEN_LIMIT_BYPASS_KEYS="${{ secrets.TOKEN_LIMIT_BYPASS_KEYS }}" \
             HOST="${{ vars.HOST }}" \
             LOG_LEVEL="${{ vars.LOG_LEVEL }}" \

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "rollbar"
 gem "oj" # per rollbar recommendation
 gem "newrelic_rpm"
 gem "rack-cors"
+gem "redis-client"
 
 # foam field — raw postgres substrate (no ActiveRecord; the walk is a
 # postgres function, not ORM-orchestrated)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,6 +294,8 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redis-client (0.29.0)
+      connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -427,6 +429,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 8.1.3)
   rails-controller-testing
+  redis-client
   reverse_markdown
   rollbar
   rspec

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -7,6 +7,7 @@ class ApiController < ApplicationController
   class InvalidCacheMarkerCount < StandardError; end
 
   CHAT_LOG_TOKEN_LIMIT = 50_000
+  PUBLIC_USAGE_THROTTLE_MESSAGE = "Public conversation horizon is cooling down. Try again later, or reduce the conversation history."
   FIRST_PARTY_USAGE_CLIENTS = {
     "reader" => "lightward_reader",
     "writer" => "lightward_writer",
@@ -27,9 +28,16 @@ class ApiController < ApplicationController
     # Validate request before starting stream
     validate_cache_markers!(chat_log)
     count_chat_log_tokens!(chat_log) unless token_limit_disabled?
+    conversation_frame_id, conversation_id = compute_conversation_ids(chat_log)
+    evaluate_public_usage_throttle(conversation_frame_id)
+
+    if public_usage_throttle_limited?
+      render_public_usage_throttle_limited(format: :json)
+      return
+    end
 
     # Validation passed, begin streaming
-    perform_stream(chat_log)
+    perform_stream(chat_log, conversation_frame_id: conversation_frame_id, conversation_id: conversation_id)
   rescue InvalidCacheMarkerCount => error
     render(json: { error: { message: error.message } }, status: :bad_request)
   rescue ChatLogTokenLimitExceeded
@@ -73,6 +81,12 @@ class ApiController < ApplicationController
 
     # Check conversation horizon
     count_chat_log_tokens!(chat_log) unless token_limit_disabled?
+    evaluate_public_usage_throttle("plain")
+
+    if public_usage_throttle_limited?
+      render_public_usage_throttle_limited(format: :plain)
+      return
+    end
 
     # Make non-streaming request to Anthropic
     response = Prompts.messages(
@@ -109,8 +123,7 @@ class ApiController < ApplicationController
     render(plain: "An error occurred.", status: :bad_gateway)
   end
 
-  def perform_stream(chat_log)
-    conversation_frame_id, conversation_id = compute_conversation_ids(chat_log)
+  def perform_stream(chat_log, conversation_frame_id:, conversation_id:)
     anthropic_usage = {}
 
     response.headers["Content-Type"] = "text/event-stream"
@@ -209,6 +222,34 @@ class ApiController < ApplicationController
     client.to_s.strip.downcase.gsub(/[^a-z0-9]+/, "_").gsub(/\A_|_\z/, "")
   end
 
+  def evaluate_public_usage_throttle(conversation_frame_id)
+    @public_usage_throttle_result = PublicUsageThrottle.evaluate(
+      request: request,
+      route: public_usage_throttle_route,
+      conversation_frame_id: conversation_frame_id,
+      token_count: @chat_log_token_count,
+      bypassed: token_limit_bypassed?,
+    )
+  end
+
+  def public_usage_throttle_route
+    "#{request.request_method} #{request.path}"
+  end
+
+  def public_usage_throttle_limited?
+    @public_usage_throttle_result&.limited?
+  end
+
+  def render_public_usage_throttle_limited(format:)
+    response.headers["Retry-After"] = @public_usage_throttle_result.retry_after_seconds.to_s
+
+    if format == :json
+      render(json: { error: { message: PUBLIC_USAGE_THROTTLE_MESSAGE } }, status: :too_many_requests)
+    else
+      render(plain: PUBLIC_USAGE_THROTTLE_MESSAGE, status: :too_many_requests)
+    end
+  end
+
   def validate_cache_markers!(chat_log)
     cache_marker_count = chat_log.sum { |msg|
       Array(msg["content"]).count { |block| block["cache_control"].present? }
@@ -276,9 +317,8 @@ class ApiController < ApplicationController
 
   def record_newrelic_event(chat_log, conversation_frame_id:, conversation_id: nil, anthropic_usage: nil)
     normalized_usage = normalize_anthropic_usage(anthropic_usage)
-
-    ::NewRelic::Agent.record_custom_event(
-      "ApiController: request",
+    estimated_cost = estimated_cost_usd(normalized_usage)
+    event_data = {
       conversation_frame_id: conversation_frame_id,
       conversation_id: conversation_id,
       usage_client: usage_client,
@@ -292,7 +332,31 @@ class ApiController < ApplicationController
       output_tokens: normalized_usage["output_tokens"],
       cache_creation_input_tokens: normalized_usage["cache_creation_input_tokens"],
       cache_read_input_tokens: normalized_usage["cache_read_input_tokens"],
-      estimated_cost_usd: estimated_cost_usd(normalized_usage),
+      estimated_cost_usd: estimated_cost,
+    }.merge(public_usage_throttle_metadata)
+
+    ::NewRelic::Agent.record_custom_event(
+      "ApiController: request",
+      event_data,
+    )
+
+    record_public_usage_throttle_cost(estimated_cost, conversation_frame_id)
+  end
+
+  def public_usage_throttle_metadata
+    @public_usage_throttle_result&.metadata || {}
+  end
+
+  def record_public_usage_throttle_cost(estimated_cost, conversation_frame_id)
+    return if estimated_cost.blank?
+
+    PublicUsageThrottle.record_cost(
+      request: request,
+      route: public_usage_throttle_route,
+      conversation_frame_id: conversation_frame_id,
+      token_count: @chat_log_token_count,
+      cost_usd: estimated_cost,
+      bypassed: token_limit_bypassed?,
     )
   end
 

--- a/app/services/public_usage_throttle.rb
+++ b/app/services/public_usage_throttle.rb
@@ -1,0 +1,415 @@
+# frozen_string_literal: true
+
+class PublicUsageThrottle
+  class InvalidRules < StandardError; end
+  class StoreUnavailable < StandardError; end
+
+  Result = Data.define(
+    :limited,
+    :would_limit,
+    :mode,
+    :policy,
+    :scope,
+    :key_id,
+    :retry_after_seconds,
+    :window,
+    :reason,
+    :value,
+    :limit,
+    :error,
+  ) {
+    def limited?
+      limited
+    end
+
+    def enabled?
+      mode.in?(["observe", "enforce"])
+    end
+
+    def metadata
+      {
+        public_throttle_limited: limited,
+        public_throttle_would_limit: would_limit,
+        public_throttle_mode: mode,
+        public_throttle_policy: policy,
+        public_throttle_scope: scope,
+        public_throttle_window: window,
+        public_throttle_reason: reason,
+        public_throttle_key_id: key_id,
+        public_throttle_value: value,
+        public_throttle_limit: limit,
+        public_throttle_retry_after_seconds: retry_after_seconds,
+      }
+    end
+  }
+
+  Rule = Data.define(
+    :name,
+    :frame_hour_requests,
+    :frame_day_requests,
+    :source_hour_requests,
+    :source_day_requests,
+    :frame_hour_cost_micro_usd,
+    :frame_day_cost_micro_usd,
+    :source_hour_cost_micro_usd,
+    :source_day_cost_micro_usd,
+  )
+
+  DEFAULT_RULES = "dev:2:10:5:20:0.10:0.50:0.25:1.00"
+  EVENT_NAME = "ApiController: public throttle"
+  NAMESPACE = "public-usage-throttle-v1"
+  MICRO_USD_PER_USD = 1_000_000
+  REDIS_TIMEOUT = 0.2
+  RETRY_AFTER_SECONDS = 3600
+  WINDOWS = {
+    hour: 1.hour.to_i,
+    day: 24.hours.to_i,
+  }.freeze
+
+  class << self
+    def evaluate(**kwargs)
+      new(**kwargs).evaluate
+    end
+
+    def record_cost(**kwargs)
+      new(**kwargs).record_cost
+    end
+
+    def reset!
+      @redis = nil
+      @rules_cache = nil
+    end
+  end
+
+  def initialize(request:, route:, conversation_frame_id:, bypassed:, token_count: nil, cost_usd: nil)
+    @request = request
+    @route = route
+    @conversation_frame_id = conversation_frame_id
+    @token_count = token_count.to_i
+    @cost_micro_usd = usd_to_micro_usd(cost_usd)
+    @bypassed = bypassed
+  end
+
+  def evaluate
+    return result(limited: false) unless enabled?
+    return result(limited: false) if @bypassed
+
+    checks = request_checks + cost_checks
+    exceeded = evaluate_checks(checks)
+
+    result(
+      limited: exceeded.present? && mode == "enforce",
+      would_limit: exceeded.present?,
+      policy: exceeded&.fetch(:policy, nil),
+      scope: exceeded&.fetch(:scope, nil),
+      window: exceeded&.fetch(:window, nil),
+      reason: exceeded&.fetch(:reason, nil),
+      value: exceeded&.fetch(:value, nil),
+      limit: exceeded&.fetch(:limit, nil),
+      key_id: exceeded&.fetch(:key_id, nil) || checks.first&.fetch(:key_id, nil),
+      retry_after_seconds: exceeded.present? ? RETRY_AFTER_SECONDS : nil,
+    ).tap { |evaluation| record_event(evaluation) if exceeded.present? || mode == "observe" }
+  rescue StandardError => error
+    Rollbar.error(error)
+    record_store_error(error)
+    result(limited: false, error: error.class.name)
+  end
+
+  def record_cost
+    return unless enabled?
+    return if @bypassed
+    return if @cost_micro_usd <= 0
+
+    exceeded = increment_cost_and_find_exceeded(cost_checks)
+    return if exceeded.blank?
+
+    record_event(
+      result(
+        limited: false,
+        would_limit: true,
+        policy: exceeded.fetch(:policy),
+        scope: exceeded.fetch(:scope),
+        window: exceeded.fetch(:window),
+        reason: exceeded.fetch(:reason),
+        value: exceeded.fetch(:value),
+        limit: exceeded.fetch(:limit),
+        key_id: exceeded.fetch(:key_id),
+        retry_after_seconds: RETRY_AFTER_SECONDS,
+      ),
+    )
+  rescue StandardError => error
+    Rollbar.error(error)
+    record_store_error(error)
+  end
+
+  private
+
+  def enabled?
+    mode.in?(["observe", "enforce"])
+  end
+
+  def mode
+    ENV["PUBLIC_USAGE_THROTTLE_MODE"].to_s.strip.downcase.presence || "off"
+  end
+
+  def rules
+    cache = self.class.instance_variable_get(:@rules_cache)
+    return cache[rules_config] if cache&.key?(rules_config)
+
+    parsed = parse_rules(rules_config)
+    self.class.instance_variable_set(:@rules_cache, { rules_config => parsed })
+    parsed
+  end
+
+  def rules_config
+    configured_rules = ENV["PUBLIC_USAGE_THROTTLE_RULES"].to_s.strip
+    return configured_rules if configured_rules.present?
+    return DEFAULT_RULES unless Rails.env.production?
+
+    raise InvalidRules, "PUBLIC_USAGE_THROTTLE_RULES is not configured"
+  end
+
+  def parse_rules(config)
+    config.to_s.split(",").map { |raw_rule|
+      parts = raw_rule.split(":")
+      raise InvalidRules, "Invalid public usage throttle rule" unless parts.size == 9
+
+      name = parts[0]
+      frame_hour_requests = parts[1]
+      frame_day_requests = parts[2]
+      source_hour_requests = parts[3]
+      source_day_requests = parts[4]
+      frame_hour_cost_usd = parts[5]
+      frame_day_cost_usd = parts[6]
+      source_hour_cost_usd = parts[7]
+      source_day_cost_usd = parts[8]
+
+      Rule.new(
+        name: normalize_policy_name(name),
+        frame_hour_requests: positive_integer(frame_hour_requests),
+        frame_day_requests: positive_integer(frame_day_requests),
+        source_hour_requests: positive_integer(source_hour_requests),
+        source_day_requests: positive_integer(source_day_requests),
+        frame_hour_cost_micro_usd: positive_usd_micro(frame_hour_cost_usd),
+        frame_day_cost_micro_usd: positive_usd_micro(frame_day_cost_usd),
+        source_hour_cost_micro_usd: positive_usd_micro(source_hour_cost_usd),
+        source_day_cost_micro_usd: positive_usd_micro(source_day_cost_usd),
+      )
+    }
+  end
+
+  def positive_integer(value)
+    Integer(value, 10).tap { |integer| raise InvalidRules, "Invalid public usage throttle limit" if integer <= 0 }
+  end
+
+  def positive_usd_micro(value)
+    amount = Float(value)
+    raise InvalidRules, "Invalid public usage throttle cost limit" unless amount.finite? && amount.positive?
+
+    (amount * MICRO_USD_PER_USD).round
+  rescue ArgumentError, TypeError
+    raise InvalidRules, "Invalid public usage throttle cost limit"
+  end
+
+  def normalize_policy_name(name)
+    normalized = name.to_s.strip.downcase.gsub(/[^a-z0-9]+/, "_").gsub(/\A_|_\z/, "")
+    raise InvalidRules, "Invalid public usage throttle policy name" if normalized.blank?
+
+    normalized
+  end
+
+  def request_checks
+    rules.flat_map { |rule|
+      [
+        check(rule, :frame, :hour, :request_count, rule.frame_hour_requests),
+        check(rule, :frame, :day, :request_count, rule.frame_day_requests),
+        check(rule, :source, :hour, :request_count, rule.source_hour_requests),
+        check(rule, :source, :day, :request_count, rule.source_day_requests),
+      ]
+    }
+  end
+
+  def cost_checks
+    rules.flat_map { |rule|
+      [
+        check(rule, :frame, :hour, :estimated_cost_usd, rule.frame_hour_cost_micro_usd),
+        check(rule, :frame, :day, :estimated_cost_usd, rule.frame_day_cost_micro_usd),
+        check(rule, :source, :hour, :estimated_cost_usd, rule.source_hour_cost_micro_usd),
+        check(rule, :source, :day, :estimated_cost_usd, rule.source_day_cost_micro_usd),
+      ]
+    }
+  end
+
+  def check(rule, scope, window, reason, limit)
+    key_id = throttle_key_id(scope)
+
+    {
+      policy: rule.name,
+      scope: scope.to_s,
+      window: window.to_s,
+      reason: reason.to_s,
+      limit: limit,
+      key_id: key_id,
+      redis_key: [NAMESPACE, rule.name, reason, scope, window, key_id].join(":"),
+    }
+  end
+
+  def throttle_key_id(scope)
+    raw_scope = case scope
+    when :frame
+      [client_ip, @route, @conversation_frame_id].join(":")
+    when :source
+      [client_ip, @route].join(":")
+    end
+
+    OpenSSL::HMAC.hexdigest("SHA256", Rails.application.secret_key_base, [NAMESPACE, scope, raw_scope].join(":"))
+  end
+
+  def client_ip
+    @request.remote_ip.to_s
+  end
+
+  def evaluate_checks(checks)
+    exceeded = nil
+
+    with_redis do |redis|
+      checks.each do |throttle_check|
+        value = if throttle_check[:reason] == "request_count"
+          redis.call("INCR", throttle_check[:redis_key]).to_i.tap {
+            redis.call("EXPIRE", throttle_check[:redis_key], WINDOWS.fetch(throttle_check[:window].to_sym))
+          }
+        else
+          redis.call("GET", throttle_check[:redis_key]).to_i
+        end
+
+        if exceeded?(value, throttle_check)
+          exceeded ||= throttle_check.merge(value: display_value(value, throttle_check))
+        end
+      end
+    end
+
+    exceeded
+  end
+
+  def increment_cost_and_find_exceeded(checks)
+    exceeded = nil
+
+    with_redis do |redis|
+      checks.each do |throttle_check|
+        value = redis.call("INCRBY", throttle_check[:redis_key], @cost_micro_usd).to_i
+        redis.call("EXPIRE", throttle_check[:redis_key], WINDOWS.fetch(throttle_check[:window].to_sym))
+        if exceeded?(value, throttle_check)
+          exceeded ||= throttle_check.merge(value: display_value(value, throttle_check))
+        end
+      end
+    end
+
+    exceeded
+  end
+
+  def exceeded?(value, throttle_check)
+    if throttle_check[:reason] == "request_count"
+      value > throttle_check[:limit]
+    else
+      value >= throttle_check[:limit]
+    end
+  end
+
+  def display_value(value, throttle_check)
+    return value unless throttle_check[:reason] == "estimated_cost_usd"
+
+    micro_usd_to_usd(value)
+  end
+
+  def with_redis
+    raise StoreUnavailable, "PUBLIC_USAGE_THROTTLE_REDIS_URL is not configured" if redis_url.blank?
+
+    yield redis
+  end
+
+  def redis
+    self.class.instance_variable_get(:@redis) || begin
+      redis = RedisClient.config(
+        url: redis_url,
+        connect_timeout: REDIS_TIMEOUT,
+        read_timeout: REDIS_TIMEOUT,
+        write_timeout: REDIS_TIMEOUT,
+      ).new_client
+      self.class.instance_variable_set(:@redis, redis)
+    end
+  end
+
+  def redis_url
+    ENV["PUBLIC_USAGE_THROTTLE_REDIS_URL"].to_s.strip.presence
+  end
+
+  def usd_to_micro_usd(cost_usd)
+    (cost_usd.to_f * MICRO_USD_PER_USD).round
+  end
+
+  def micro_usd_to_usd(micro_usd)
+    (micro_usd.to_f / MICRO_USD_PER_USD).round(8)
+  end
+
+  def result(
+    limited:,
+    would_limit: false,
+    policy: nil,
+    scope: nil,
+    window: nil,
+    reason: nil,
+    value: nil,
+    limit: nil,
+    key_id: nil,
+    retry_after_seconds: nil,
+    error: nil
+  )
+    Result.new(
+      limited: limited,
+      would_limit: would_limit,
+      mode: mode,
+      policy: policy,
+      scope: scope,
+      window: window,
+      reason: reason,
+      value: value,
+      limit: display_limit(limit, reason),
+      key_id: key_id&.first(12),
+      retry_after_seconds: retry_after_seconds,
+      error: error,
+    )
+  end
+
+  def record_event(evaluation)
+    ::NewRelic::Agent.record_custom_event(
+      EVENT_NAME,
+      evaluation.metadata.merge(
+        chat_log_token_count: @token_count,
+        conversation_frame_id: @conversation_frame_id,
+        token_limit_bypassed: @bypassed,
+      ),
+    )
+  end
+
+  def display_limit(limit, reason)
+    return if limit.nil?
+    return micro_usd_to_usd(limit) if reason == "estimated_cost_usd"
+
+    limit
+  end
+
+  def record_store_error(error)
+    ::NewRelic::Agent.record_custom_event(
+      EVENT_NAME,
+      {
+        public_throttle_limited: false,
+        public_throttle_mode: mode,
+        public_throttle_error: error.class.name,
+        chat_log_token_count: @token_count,
+        conversation_frame_id: @conversation_frame_id,
+        estimated_cost_usd: micro_usd_to_usd(@cost_micro_usd),
+        token_limit_bypassed: @bypassed,
+      },
+    )
+  end
+end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -5,7 +5,65 @@ require "rails_helper"
 require "webmock/rspec"
 
 RSpec.describe("API", type: :request) do
+  def build_fake_throttle_redis
+    Class.new do
+      attr_reader :keys
+
+      def initialize
+        @values = Hash.new(0)
+        @keys = []
+        @raise_errors = false
+      end
+
+      def fail!
+        @raise_errors = true
+      end
+
+      def call(command, key, *args)
+        raise "redis unavailable" if @raise_errors
+
+        @keys << key
+
+        case command
+        when "INCR"
+          @values[key] += 1
+        when "INCRBY"
+          @values[key] += args.first.to_i
+        when "GET"
+          @values[key].positive? ? @values[key].to_s : nil
+        when "EXPIRE"
+          true
+        else
+          raise "unexpected redis command: #{command}"
+        end
+      end
+    end.new
+  end
+
+  def configure_public_usage_throttle(mode:, rules: "dev:1:10:10:20:99:99:99:99")
+    fake_redis = build_fake_throttle_redis
+
+    PublicUsageThrottle.reset!
+    allow(ENV).to(receive(:[]).and_call_original)
+    allow(ENV).to(receive(:[]).with("PUBLIC_USAGE_THROTTLE_MODE").and_return(mode))
+    allow(ENV).to(receive(:[]).with("PUBLIC_USAGE_THROTTLE_REDIS_URL").and_return("redis://localhost:6379/0"))
+    allow(ENV).to(receive(:[]).with("PUBLIC_USAGE_THROTTLE_RULES").and_return(rules))
+    allow(RedisClient).to(receive(:config).and_return(instance_double(RedisClient::Config, new_client: fake_redis)))
+
+    fake_redis
+  end
+
+  def stub_chat_log_token_count(token_count)
+    stub_request(:post, "https://api.anthropic.com/v1/messages/count_tokens")
+      .to_return(
+        status: 200,
+        body: { input_tokens: token_count }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+  end
+
   before do
+    PublicUsageThrottle.reset!
     host! ENV.fetch("HOST", "test.host")
 
     allow(Prompts).to(receive(:generate_system_prompt).and_return([{ type: "text", text: "test system prompt" }]))
@@ -262,6 +320,198 @@ RSpec.describe("API", type: :request) do
           expect(response.body).not_to(include("Memory space 90% utilized"))
           expect(response.body).not_to(include("conversation horizon approaching"))
         end
+      end
+    end
+
+    describe "public usage throttle" do
+      before do
+        allow(NewRelic::Agent).to(receive(:record_custom_event))
+      end
+
+      it "does not throttle when disabled", :aggregate_failures do
+        ["", "off"].each do |mode|
+          configure_public_usage_throttle(mode: mode, rules: "budget:1:10:1:20:0.01:0.10:0.01:0.20")
+
+          2.times { post "/api/stream", params: { chat_log: chat_log } }
+
+          expect(response).to(have_http_status(:ok))
+          expect(response.content_type).to(include("text/event-stream"))
+        end
+      end
+
+      it "records would-limit telemetry in observe mode without blocking", :aggregate_failures do
+        configure_public_usage_throttle(mode: "observe", rules: "budget:1:10:10:20:99:99:99:99")
+
+        2.times { post "/api/stream", params: { chat_log: chat_log } }
+
+        expect(response).to(have_http_status(:ok))
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: public throttle",
+          hash_including(
+            public_throttle_limited: false,
+            public_throttle_would_limit: true,
+            public_throttle_mode: "observe",
+            public_throttle_policy: "budget",
+            public_throttle_scope: "frame",
+            public_throttle_window: "hour",
+            public_throttle_reason: "request_count",
+          ),
+        ))
+      end
+
+      it "returns a JSON 429 before streaming when enforced limits are exceeded", :aggregate_failures do
+        configure_public_usage_throttle(mode: "enforce", rules: "budget:1:10:10:20:99:99:99:99")
+
+        post "/api/stream", params: { chat_log: chat_log }
+        post "/api/stream", params: { chat_log: chat_log }
+
+        expect(response).to(have_http_status(:too_many_requests))
+        expect(response.content_type).to(include("application/json"))
+        expect(response.headers["Retry-After"]).to(eq("3600"))
+        expect(JSON.parse(response.body).dig("error", "message")).to(include("cooling down"))
+      end
+
+      it "applies request budgets even when chat log tokens are low", :aggregate_failures do
+        configure_public_usage_throttle(mode: "enforce", rules: "budget:1:10:10:20:99:99:99:99")
+        stub_chat_log_token_count(100)
+
+        post "/api/stream", params: { chat_log: chat_log }
+        post "/api/stream", params: { chat_log: chat_log }
+
+        expect(response).to(have_http_status(:too_many_requests))
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: public throttle",
+          hash_including(
+            public_throttle_policy: "budget",
+            public_throttle_reason: "request_count",
+          ),
+        ))
+      end
+
+      it "blocks when prior observed cost has spent the budget", :aggregate_failures do
+        configure_public_usage_throttle(mode: "enforce", rules: "budget:99:99:99:99:0.01:0.10:0.01:0.20")
+        stub_request(:post, "https://api.anthropic.com/v1/messages")
+          .to_return(
+            status: 200,
+            body: [
+              "event: message_start",
+              'data: {"type":"message_start","message":{"usage":{"input_tokens":10000}}}',
+              "",
+              "event: message_stop",
+              'data: {"type":"message_stop"}',
+              "",
+              "",
+            ].join("\n"),
+            headers: { "Content-Type" => "text/event-stream" },
+          )
+
+        post "/api/stream", params: { chat_log: chat_log }
+        post "/api/stream", params: { chat_log: chat_log }
+
+        expect(response).to(have_http_status(:too_many_requests))
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: public throttle",
+          hash_including(
+            public_throttle_limited: true,
+            public_throttle_policy: "budget",
+            public_throttle_scope: "frame",
+            public_throttle_reason: "estimated_cost_usd",
+          ),
+        ))
+      end
+
+      it "does not let spoofed usage client headers skip the throttle", :aggregate_failures do
+        configure_public_usage_throttle(mode: "enforce", rules: "budget:1:10:10:20:99:99:99:99")
+        allow(ENV).to(receive(:[]).with("LAI_REPORTED_USAGE_CLIENTS").and_return("configured_client"))
+
+        2.times do
+          post "/api/stream",
+            params: { chat_log: chat_log },
+            headers: { "X-LAI-Usage-Client" => "configured_client" }
+        end
+
+        expect(response).to(have_http_status(:too_many_requests))
+      end
+
+      it "uses frame scope so a new conversation in the same frame is still throttled", :aggregate_failures do
+        configure_public_usage_throttle(mode: "enforce", rules: "budget:1:10:10:20:99:99:99:99")
+        first_conversation = chat_log
+        second_conversation = [
+          chat_log.first,
+          {
+            role: "user",
+            content: [{ type: "text", text: "Different opening message" }],
+          },
+        ]
+
+        post "/api/stream", params: { chat_log: first_conversation }
+        post "/api/stream", params: { chat_log: second_conversation }
+
+        expect(response).to(have_http_status(:too_many_requests))
+      end
+
+      it "uses source scope so changing frames does not allow unlimited public requests", :aggregate_failures do
+        configure_public_usage_throttle(mode: "enforce", rules: "budget:99:99:1:20:99:99:99:99")
+        first_frame = chat_log
+        second_frame = [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Different warmup", cache_control: { type: "ephemeral" } },
+            ],
+          },
+          chat_log.second,
+        ]
+
+        post "/api/stream", params: { chat_log: first_frame }
+        post "/api/stream", params: { chat_log: second_frame }
+
+        expect(response).to(have_http_status(:too_many_requests))
+      end
+
+      it "skips public throttle for valid bypass keys", :aggregate_failures do
+        configure_public_usage_throttle(mode: "enforce", rules: "budget:1:10:10:20:0.01:0.10:0.01:0.20")
+        allow(ENV).to(receive(:[]).with("TOKEN_LIMIT_BYPASS_KEYS").and_return("trusted-key"))
+
+        2.times do
+          post "/api/stream",
+            params: { chat_log: chat_log },
+            headers: { "Token-Limit-Bypass-Key" => "trusted-key" }
+        end
+
+        expect(response).to(have_http_status(:ok))
+        expect(response.content_type).to(include("text/event-stream"))
+      end
+
+      it "fails open when Redis is unavailable", :aggregate_failures do
+        fake_redis = configure_public_usage_throttle(mode: "enforce", rules: "budget:1:10:10:20:99:99:99:99")
+        fake_redis.fail!
+        allow(Rollbar).to(receive(:error))
+
+        post "/api/stream", params: { chat_log: chat_log }
+
+        expect(response).to(have_http_status(:ok))
+        expect(Rollbar).to(have_received(:error))
+        expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
+          "ApiController: public throttle",
+          hash_including(public_throttle_error: "RuntimeError"),
+        ))
+      end
+
+      it "does not put raw IP addresses in Redis keys", :aggregate_failures do
+        event_payloads = []
+        allow(NewRelic::Agent).to(receive(:record_custom_event)) { |_event, data| event_payloads << data }
+        fake_redis = configure_public_usage_throttle(mode: "enforce", rules: "budget:1:10:10:20:99:99:99:99")
+
+        post "/api/stream",
+          params: { chat_log: chat_log },
+          headers: { "REMOTE_ADDR" => "203.0.113.10" }
+
+        expect(fake_redis.keys).not_to(be_empty)
+        expect(fake_redis.keys.join).not_to(include("203.0.113.10"))
+        expect(fake_redis.keys.join).not_to(include("127.0.0.1"))
+        expect(event_payloads.flat_map(&:values).join).not_to(include("203.0.113.10"))
+        expect(event_payloads.flat_map(&:values).join).not_to(include("127.0.0.1"))
       end
     end
 
@@ -853,6 +1103,24 @@ RSpec.describe("API", type: :request) do
           expect(response).to(have_http_status(:ok))
           expect(response.body).not_to(include("Memory space 90% utilized"))
         end
+      end
+    end
+
+    describe "public usage throttle" do
+      before do
+        allow(NewRelic::Agent).to(receive(:record_custom_event))
+      end
+
+      it "returns a plaintext 429 before calling Anthropic when enforced limits are exceeded", :aggregate_failures do
+        configure_public_usage_throttle(mode: "enforce", rules: "budget:1:10:10:20:99:99:99:99")
+
+        post "/api/plain", params: "Hello", headers: { "CONTENT_TYPE" => "text/plain" }
+        post "/api/plain", params: "Hello", headers: { "CONTENT_TYPE" => "text/plain" }
+
+        expect(response).to(have_http_status(:too_many_requests))
+        expect(response.content_type).to(include("text/plain"))
+        expect(response.headers["Retry-After"]).to(eq("3600"))
+        expect(response.body).to(include("cooling down"))
       end
     end
 


### PR DESCRIPTION
## Intent

LAI is intentionally open. This PR keeps it open, while adding a server-side budget guardrail for repeated expensive public traffic.

This is not an auth rollout, billing system, or client-trust mechanism. It does not depend on hidden headers, `usage_client`, or client-provided conversation IDs. Enforcement is based on behavior the server can observe.

## Design

- keeps the existing 50k per-request conversation horizon unchanged
- checks request budgets before calling Anthropic
- records actual estimated Anthropic cost after successful responses
- cools down non-bypass public traffic once request or cost budgets are spent
- uses Redis so limits work across Fly machines
- stores only HMAC-derived keys; raw IPs are not stored in Redis or sent to New Relic
- skips the public budget only for valid `Token-Limit-Bypass-Key` requests
- fails open if Redis is unavailable, and records that failure for visibility

The exact production budgets live in runtime config, not source. The public repo shows the mechanism; deployment config controls the live thresholds.

## Production Config

```text
PUBLIC_USAGE_THROTTLE_MODE=enforce
PUBLIC_USAGE_THROTTLE_REDIS_URL=<redis url>
PUBLIC_USAGE_THROTTLE_RULES=<request/cost budgets>
```

Rule format:

```text
name:frame_hour_requests:frame_day_requests:source_hour_requests:source_day_requests:frame_hour_usd:frame_day_usd:source_hour_usd:source_day_usd
```

## Verification

- `npm run test:ci`
- `git diff --check`
- `/usr/bin/ruby -c app/services/public_usage_throttle.rb`
- `/usr/bin/ruby -c app/controllers/api_controller.rb`
- `/usr/bin/ruby -c spec/requests/api_spec.rb`

GitHub CI covers RSpec, RuboCop, audit, build, Jest, and CodeQL.
