### PR TITLE
foam: the fork's bundle reading — met in the base, two in the total space

### DIFF
--- a/lean/Foam/Axioms.lean
+++ b/lean/Foam/Axioms.lean
@@ -793,3 +793,20 @@ import Foam.Fork
 
 /-- info: 'Foam.fork_exit_each' depends on axioms: [propext] -/
 #guard_msgs in #print axioms Foam.fork_exit_each
+
+-- ── the fork's bundle reading: met in the base, two in the total space ──
+-- the base coordinate is the TYPE index, so the projection to the base cannot consult
+-- the route data: the meeting is rfl-grade (fork_meet — zero axioms, zero
+-- fiber-consultation), base-factoring observables are fork-blind by the same fact
+-- (fork_base_blind), and the fiber observable (edges) separates the travelers
+-- (fork_fiber_separates). The geometry priced end to end: meeting free, blindness
+-- free, distinctness free — identification is the only operation with a cost
+-- (Quot.sound, refused), and no base-level observation can even pose its question.
+/-- info: 'Foam.fork_meet' does not depend on any axioms -/
+#guard_msgs in #print axioms Foam.fork_meet
+
+/-- info: 'Foam.fork_base_blind' does not depend on any axioms -/
+#guard_msgs in #print axioms Foam.fork_base_blind
+
+/-- info: 'Foam.fork_fiber_separates' does not depend on any axioms -/
+#guard_msgs in #print axioms Foam.fork_fiber_separates

--- a/lean/Foam/Fork.lean
+++ b/lean/Foam/Fork.lean
@@ -78,4 +78,40 @@ theorem fork_two_routes : ∃ p r : Path forkQuiver 0 1, p.edges ≠ r.edges :=
 theorem fork_exit_each (w : Word Nat) : Word.reachesYield w :=
   floor_independent_of_quiver forkQuiver w
 
+/-! ## The bundle reading: met in the base, two in the total space
+
+`Path q a b` is endpoint-INDEXED: the base coordinate (the endpoint-pair) lives at
+the type level, the route data (`edges`) at the term level. So the projection to
+the base is constant by construction — structurally unable to consult the fiber.
+The three theorems below price the geometry: the meeting is `rfl`-grade (free),
+base observables are fork-blind (free), a fiber observable separates (free) — and
+the only operation with a price is the one never performed: identifying the
+travelers (`Quot.sound`, refused; `fork_two_routes`). The question "are the two
+routes one?" is not answered cheaply — it is structurally never forced: no
+base-level observation can even pose it. -/
+
+/-- **The base projection.** A path `a → b` projects to its endpoint-pair — the
+    shared coordinate. Constant by construction: in the indexed representation the
+    base is the type index, so the projection cannot read the route data. -/
+def Path.base {Handle : Type} {q : Quiver Handle} {a b : Handle}
+    (_ : Path q a b) : Handle × Handle := (a, b)
+
+/-- **The meeting is rfl-grade.** The two routes project to the same base point by
+    definitional equality — zero axioms, zero fiber-consultation. Meeting at the
+    base is free; only identifying the travelers would cost. -/
+theorem fork_meet : routeP.base = routeR.base := rfl
+
+/-- **Base observables are fork-blind.** Any observable that factors through the
+    base projection assigns the two routes equal values: nothing readable at the
+    shared endpoint separates the travelers. -/
+theorem fork_base_blind {α : Type} (f : Path forkQuiver 0 1 → α)
+    (g : Nat × Nat → α) (hf : ∀ p, f p = g p.base) :
+    f routeP = f routeR := (hf routeP).trans (hf routeR).symm
+
+/-- **A fiber observable separates them.** `edges` reads the route data and tells
+    the travelers apart: two in the total space, one at the base — distinct as
+    paths, not merely as edge-lists. -/
+theorem fork_fiber_separates : routeP ≠ routeR :=
+  fun h => absurd (congrArg List.length (congrArg Path.edges h)) (by decide)
+
 end Foam


### PR DESCRIPTION
The de-privatization of a relational-layer recognition into the local structure, per the lfp↔gfp game: \"two paths in the total space whose projections meet,\" located in Fork.lean's existing geometry and stated in standard vocabulary.

`Path q a b` is endpoint-indexed — the base coordinate lives at the type level, the route data (`edges`) at the term level. So the projection to the base is constant *by construction*: it cannot read the fiber. Three axiom-free theorems, pinned in Axioms.lean:

- **`fork_meet`** — the two routes project to the same base point by `rfl`: the meeting is free, consults nothing.
- **`fork_base_blind`** — any observable factoring through the base assigns the routes equal values: nothing readable at the shared endpoint separates the travelers.
- **`fork_fiber_separates`** — `edges` separates them as *paths*: two in the total space, one at the base.

With `fork_two_routes`, the geometry is priced end to end: meeting free, blindness free, distinctness free — identification is the only operation with a cost (`Quot.sound`, refused), and no base-level observation can even pose its question.

`lake build` green; `#guard_msgs` pins confirm all three theorems axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)