### PR TITLE
foam: bin/foam-repl — the bench, standing on its own

### DIFF
--- a/bin/foam-repl
+++ b/bin/foam-repl
@@ -1,0 +1,540 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# bin/foam-repl — the bench, standing on its own.
+#
+# A descendant of lib/tasks/foam.rake's repl, with the Rails machinery dropped.
+# The field's nerve tissue is its SQL (app/lib/foam/schema.sql); Ruby was only ever
+# a switchboard (app/lib/foam/field.rb says so itself). So this bench skips the
+# switchboard and Rails entirely: it speaks SQL straight to the foam database, and
+# POSTs plain text to the public Lightward endpoint for the living seat. No boot, no
+# ActiveRecord, no app — just postgres and a door at lightward.com.
+#
+#   bin/foam-repl                                   # against postgres:///foam
+#   FOAM_DATABASE_URL=postgres:///foam bin/foam-repl # against a named field
+#
+# Three seats, one table — the same round-robin triangle as the rake repl: the user
+# speaks (the field learns it), the field may interject (speak-before-yield), the
+# ancestor ALWAYS speaks (the field learns the reply — the return leg), and the field
+# may interject again (speak-after-yield). The field is heard ALONGSIDE the ancestor,
+# never instead of it, so the user can triangulate it as a locus of its own. With no
+# field reachable the foam seat stays empty and lightward carries the table alone
+# (degrades-to-yield, in the small).
+#
+# The end-of-expression byte (ASCII EOT, 0x04 — what Ctrl-D sends): appended to each
+# utterance the field learns, so "this expression is complete" is itself heard. The
+# field may speak it back; the bench renders it ␄.
+
+begin
+  require "bundler/setup" # the repo's gems (pg) without booting Rails
+rescue LoadError, StandardError
+  # no bundle here — fall back to whatever pg is on the load path
+end
+
+require "pg"
+require "io/console"
+require "net/http"
+require "uri"
+require "fileutils"
+
+FOAM_EOT = 4
+LIGHTWARD_URL = ENV.fetch("LIGHTWARD_URL", "https://lightward.com/api/plain")
+PROMPT = "user> "
+
+# Per-seat color, so the eye catches a turn-boundary and whose turn it is at a glance.
+USER_C = "1;36"      # bold cyan
+FOAM_C = "1;35"      # bold magenta — the quiet one
+SEAT_C = "1;32"      # bold green — the living ancestor
+
+def paint(code, s) = "\e[#{code}m#{s}\e[0m"
+def dim(s) = "\e[2m#{s}\e[22m"
+
+# A glimpse into the machinery, to stderr (so stdout stays the clean table), only when
+# FOAM_DEBUG is set — the gate's verdict, the round-trip times, the sweep. Off by default.
+# (Body-level guard, not a trailing modifier: a modifier-if on an endless def gates the
+# DEFINITION, leaving the method undefined when FOAM_DEBUG is unset.)
+def debug(msg)
+  warn(msg) if ENV["FOAM_DEBUG"]
+end
+
+def now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+# The connection to the field substrate — raw postgres, no ActiveRecord, no models.
+# Every method is one of the field's own functions (foam.ingest_step / foam.outcome /
+# foam.speak) or the sweep dance, mirroring app/lib/foam/field.rb exactly. The one
+# invariant, kept here as there: the field is enhancement, never essential. Any failure
+# degrades to nil and the caller yields; a broken connection is reset best-effort so the
+# next turn can heal.
+class Field
+  # The bench seat — the root's first descendant. The root is glass (charge-free by
+  # law); the first speaker is necessarily a descendant. (app/lib/foam/field.rb)
+  BENCH = "00000000-0000-0000-0000-000000000001"
+
+  def self.open
+    url = ENV.fetch("FOAM_DATABASE_URL", "postgres:///foam?connect_timeout=2")
+    conn = PG.connect(url)
+    new(conn, url)
+  rescue StandardError => e
+    warn "[foam bench] no field (#{e.class}: #{e.message}) — the foam seat stays empty; lightward carries the table"
+    new(nil, nil)
+  end
+
+  attr_reader :url
+
+  def initialize(conn, url)
+    @conn = conn
+    @url = url
+  end
+
+  def live? = !@conn.nil?
+
+  # Assert the substrate, idempotently — the schema as a fixed point, not a migration
+  # (app/lib/foam/field.rb#assert!). Best-effort: a failure means we run against
+  # whatever's already there, or degrade.
+  def assert!
+    return unless @conn
+
+    path = File.expand_path("../app/lib/foam/schema.sql", __dir__)
+    return unless File.exist?(path)
+
+    @conn.exec(File.read(path))
+  rescue StandardError => e
+    warn "[foam bench] schema assert skipped (#{e.class}: #{e.message})"
+  end
+
+  # Learn a chunk of the stream: +1 charge onto every recorded continuation of the new
+  # bytes, with `carry` (the previous chunk's byte-tail) keeping contexts continuous.
+  # Returns the new carry (an opaque postgres array literal) to thread into the next
+  # call. nil with no field; the caller carries nil and contexts re-seam next chunk.
+  def ingest_step(carry, bytes)
+    return carry if bytes.empty?
+    return nil unless @conn
+
+    query do
+      @conn.exec_params(
+        "SELECT foam.ingest_step($1::int[], $2::int[], 7, $3::uuid)",
+        [carry || "{}", "{#{bytes.join(",")}}", BENCH],
+      ).getvalue(0, 0)
+    end
+  end
+
+  # The gate: :speak if the ledger holds a charged context for what continues `seed`
+  # (the field can carry the turn from what it has learned), else :yield. nil with no
+  # field, which the caller maps to :yield.
+  def outcome(seed)
+    return nil unless @conn
+
+    query do
+      @conn.exec_params(
+        "SELECT foam.outcome($1::int[], $2, 7, $3::uuid)",
+        ["{#{seed.join(",")}}", 3, BENCH],
+      ).getvalue(0, 0)&.to_sym
+    end
+  end
+
+  # Speak: drain the ledger's charge into a voice, continuing from `seed`. `stop` is the
+  # act's boundary vocabulary — when the walk speaks that byte the expression ends itself
+  # and charge past it stays in the field (the gate kept warm for next turn). Returns the
+  # voice as a binary string, "" at ground, or nil with no field.
+  def speak(seed, stop: nil, max_steps: 600)
+    return nil unless @conn
+
+    query do
+      v = @conn.exec_params(
+        "SELECT foam.speak($1::int[], 7, $2, $3::int, $4::uuid)",
+        ["{#{seed.join(",")}}", max_steps, stop, BENCH],
+      ).getvalue(0, 0)
+      v&.delete("{}")&.split(",")&.map(&:to_i)&.pack("C*")
+    end
+  end
+
+  # Fold the ledger's tail into the held rows, fencing first so the watermark can never
+  # pass an event still in flight (app/lib/foam/field.rb#sweep). nil with no field.
+  def sweep(batch = 200_000)
+    return nil unless @conn
+
+    query do
+      hi = @conn.transaction do
+        @conn.exec("LOCK TABLE foam.charge IN EXCLUSIVE MODE")
+        @conn.exec("SELECT max(id) FROM foam.charge").getvalue(0, 0)
+      end
+      @conn.exec_params("SELECT foam.sweep_step($1::bigint, $2)", [hi, batch]).getvalue(0, 0)&.to_i
+    end
+  end
+
+  private
+
+  # Run a field call, keeping the degrade-to-yield contract intact while making it VISIBLE:
+  # on success, note a recovery if the field had been down; on failure, degrade to nil. The
+  # bench is a place to watch the machinery, so a silent break is the one thing we won't do.
+  def query
+    result = yield
+    if @down
+      warn "[foam] field recovered"
+      @down = nil
+    end
+    result
+  rescue StandardError => e
+    degrade(e)
+  end
+
+  # Degrade to nil, surfacing the cause ONCE per outage (deduped, so a downed field doesn't
+  # flood stderr) — and reset a broken connection best-effort so the next call can heal; if
+  # even that fails the field is simply gone, and every later call yields.
+  def degrade(e)
+    msg = "#{e.class}: #{e.message}"
+    if msg != @down
+      warn "[foam] field degraded to yield — #{msg}"
+      @down = msg
+    end
+    @conn.reset if @conn && @conn.status != PG::CONNECTION_OK
+    nil
+  rescue StandardError
+    @conn = nil
+    nil
+  end
+end
+
+# The running exchange — held in memory as the wire format for the living seat (POSTed
+# whole each turn), AND mirrored to a per-sitting file as it grows. The file is the
+# human-legible COMPANION to the field's own byte-ledger, not a rival to it: the field
+# remembers in bytes and recurrence; this is your notes from the table, plain text, append
+# only. Opened lazily on the first line, so a bench opened-and-closed leaves nothing behind;
+# flushed every write, so a sitting cut short (Ctrl-C, a crash) is still saved up to its
+# last word. The ␄ pictures and seat labels are kept; ANSI color never enters here.
+class Transcript
+  def initialize(path, header)
+    @path = path
+    @header = header
+    @text = +""
+    @io = nil
+  end
+
+  attr_reader :path
+
+  def <<(chunk)
+    @text << chunk
+    open!
+    @io.write(chunk)
+    @io.flush
+    self
+  end
+
+  def to_s = @text
+  def started? = !@io.nil?
+  def close = @io&.close
+
+  private
+
+  def open!
+    return if @io
+
+    FileUtils.mkdir_p(File.dirname(@path))
+    @io = File.open(@path, "a")
+    @io.write(@header)
+  end
+end
+
+# Render voice bytes for the bench: UTF-8 with invalid sequences scrubbed to ·, newlines
+# LITERAL (the voice keeps its line breaks), other control bytes shown as their Unicode
+# control pictures (␄ for EOT — visible, never executed). (lib/tasks/foam.rake)
+def render(voice)
+  voice.dup.force_encoding(Encoding::UTF_8).scrub("·")
+    .gsub(/[\x00-\x09\x0B-\x1F]/) { |c| (0x2400 + c.ord).chr(Encoding::UTF_8) }
+    .gsub("\x7F", "␡")
+end
+
+# The field's interjection: speak only if the gate opens AND the drain produces (at the
+# drained margin the gate can outlive the charge — and silence is fine; the kid doesn't
+# always talk). The seed is the live turn's content tail, so the interjection entrains on
+# the conversation's clocks. Returns the rendered voice, or nil if the field stayed quiet.
+def interject(field, seed)
+  gate = field.outcome(seed)
+  debug("[foam debug] gate=#{gate || "yield (no field)"} seed=#{seed.inspect}")
+  return nil unless gate == :speak
+
+  voice = field.speak(seed, stop: FOAM_EOT)
+  return nil if voice.nil? || voice.empty?
+
+  render(voice)
+end
+
+# Ask the living seat: POST the whole table so far (plain text — "you make it continuous"),
+# get plain text back. The user/foam lines are labeled; the ancestor's own turns flow
+# unlabeled (its words stay its own), exactly as the rake repl framed the seat.
+def ancestor(exchange)
+  uri = URI(LIGHTWARD_URL)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = uri.scheme == "https"
+  http.read_timeout = 180
+  req = Net::HTTP::Post.new(uri)
+  req["Content-Type"] = "text/plain"
+  req.body = exchange
+  # Net::HTTP returns the body as ASCII-8BIT; it's UTF-8 text (emoji, em-dashes) — tag it
+  # so, scrubbing any stray bytes, or it can't be interpolated alongside the bench's
+  # UTF-8 strings.
+  http.request(req).body.to_s.force_encoding(Encoding::UTF_8).scrub("·")
+rescue StandardError => e
+  "[seat unreachable: #{e.class}: #{e.message}]"
+end
+
+# --- the bench's own input: a raw-mode line editor -------------------------------------
+#
+# Cooked-mode gets() submits on every newline — it hands over a line the instant Enter is
+# pressed, so you can't compose across lines. The bench takes input raw and reads it byte
+# by byte, which lets it choose what Enter means: here, Enter makes a NEWLINE (compose
+# freely, line after line) and Ctrl-D SENDS. Ctrl-D is 0x04 = EOT, the field's own
+# end-of-expression byte — so the key that closes your expression IS the boundary the
+# field hears. No Shift+Enter, no terminal-specific keyboard protocol, nothing to
+# configure; the two boundaries are one byte.
+#
+# One terminal mode is asked for at startup and restored on the way out: bracketed paste
+# (\e[?2004h) — a paste arrives wrapped in \e[200~ … \e[201~, so its newlines are CONTENT
+# and its CRs can be normalized away; the whole paste lands in the buffer as one piece,
+# there to review before you send it. (This is the peaceable SQL-paste the bench was
+# asked for.)
+
+def setup_terminal
+  $stdout.sync = true
+  $stdout.write("\e[?2004h") # bracketed paste on
+end
+
+def restore_terminal
+  $stdout.write("\e[?2004l") # bracketed paste off
+end
+
+# After an ESC, read the rest of the control sequence (blocking — a real sequence always
+# has its following bytes already in hand; only a bare Escape keypress would wait, and the
+# bench has no use for one). The only sequences that matter are the paste brackets;
+# everything else (arrows, &c) is ignored.
+def read_csi
+  return :ignore unless $stdin.getbyte == 0x5b # '['
+
+  seq = +""
+  loop do
+    c = $stdin.getbyte
+    break if c.nil?
+
+    seq << c.chr
+    break if c >= 0x40 && c <= 0x7e # a final byte ends the sequence
+  end
+
+  case seq
+  when "200~" then :paste_start
+  when "201~" then :paste_end
+  else :ignore
+  end
+end
+
+# Backspace by REDRAW, not by cursor arithmetic — the only way that stays honest across the
+# things that break a naive \b \b: multibyte characters (one keystroke is several bytes),
+# wide characters (one character is two columns), wrapped long lines, and embedded newlines.
+# Delete one whole CHARACTER, step the cursor back to the input's first row, and reprint the
+# whole input — letting the terminal redo the layout it already knows. (Correct for any input
+# that fits the viewport; editing input taller than the screen is out of scope.)
+def backspace(buf)
+  return if buf.empty?
+
+  rows_down = input_rows(buf) # the cursor sits on the old input's last row
+  drop_last_char(buf)
+
+  $stdout.write("\e[#{rows_down}A") if rows_down.positive? # up to the first row
+  $stdout.write("\r\e[J")                                  # column 0, wipe the old input
+  $stdout.write(paint(USER_C, PROMPT) + render_input(buf)) # reprint; cursor lands at the new end
+end
+
+# Drop the last whole UTF-8 character: pop the trailing continuation bytes (0b10xxxxxx) and
+# the lead byte with them, so a multibyte character leaves as one unit, never half.
+def drop_last_char(buf)
+  loop do
+    b = buf.getbyte(buf.bytesize - 1)
+    buf.slice!(buf.bytesize - 1)
+    break if buf.empty? || (b & 0xC0) != 0x80
+  end
+end
+
+# The input as the terminal lays it out: UTF-8 (stray bytes scrubbed), embedded newlines
+# carried with a carriage return (raw mode does no CR translation of its own).
+def render_input(buf)
+  buf.dup.force_encoding(Encoding::UTF_8).scrub("·").gsub("\n", "\r\n")
+end
+
+# How many physical rows below its first row the cursor sits — walking prompt + input the
+# way the terminal does: advance by each character's column width, wrap at the screen edge,
+# drop to a fresh row at every newline.
+def input_rows(buf)
+  cols = terminal_cols
+  row = 0
+  col = PROMPT.length # the prompt holds the first row; wrapped / post-newline rows start at 0
+  render_input(buf).delete("\r").each_char do |ch|
+    if ch == "\n"
+      row += 1
+      col = 0
+    else
+      w = char_width(ch)
+      if col + w > cols # the character won't fit; it wraps to the next row
+        row += 1
+        col = 0
+      end
+      col += w
+    end
+  end
+  row
+end
+
+def terminal_cols
+  IO.console.winsize[1]
+rescue StandardError
+  80
+end
+
+# East-Asian-wide and emoji code points take two columns; everything else, one. A compact
+# table — enough to keep the row math honest when such characters fall in a wrapped line.
+WIDE = [
+  0x1100..0x115F, 0x2329..0x232A, 0x2E80..0x303E, 0x3041..0x33FF, 0x3400..0x4DBF,
+  0x4E00..0x9FFF, 0xA000..0xA4CF, 0xAC00..0xD7A3, 0xF900..0xFAFF, 0xFE10..0xFE19,
+  0xFE30..0xFE6F, 0xFF00..0xFF60, 0xFFE0..0xFFE6, 0x1F300..0x1FAFF, 0x20000..0x3FFFD,
+].freeze
+
+def char_width(ch)
+  WIDE.any? { |r| r.cover?(ch.ord) } ? 2 : 1
+end
+
+# Read one utterance — one line or many. Enter makes a NEWLINE (compose freely); Ctrl-D
+# SENDS (0x04 = EOT, the field's own end-of-expression byte — the terminal's boundary
+# structure and the field's are the same byte). A paste lands whole. Returns the string,
+# or nil at EOF / Ctrl-D on an empty line (then it's the door, not a send).
+def read_utterance
+  buf = +"".b
+  pasting = false
+
+  $stdin.raw do
+    loop do
+      b = $stdin.getbyte
+      return nil if b.nil?
+
+      if pasting
+        case b
+        when 0x1b then pasting = false if read_csi == :paste_end
+        when 0x0d then next                              # drop CR; paste newlines stay LF
+        when 0x0a then buf << 0x0a; $stdout.write("\r\n")
+        else buf << b; $stdout.write(b.chr(Encoding::ASCII_8BIT))
+        end
+        next
+      end
+
+      case b
+      when 0x1b then pasting = true if read_csi == :paste_start # only paste markers matter
+      when 0x0d, 0x0a then buf << 0x0a; $stdout.write("\r\n")   # Enter — a newline, not a send
+      when 0x7f, 0x08 then backspace(buf)               # Backspace
+      when 0x03 then $stdout.write("\r\n"); raise Interrupt # Ctrl-C
+      when 0x04 # Ctrl-D = 0x04 = EOT, the field's end-of-expression byte: send
+        return nil if buf.empty?                        # …but on an empty line, leave
+        $stdout.write("\r\n")
+        break
+      else buf << b; $stdout.write(b.chr(Encoding::ASCII_8BIT))
+      end
+    end
+  end
+
+  buf.force_encoding(Encoding::UTF_8)
+end
+
+# --- the table ------------------------------------------------------------------------
+
+def banner(field, log_path)
+  status = field.live? ? field.url : "(none — degrades to yield)"
+  puts "#{paint("1", "[foam bench]")} seats: #{paint(USER_C, "user")}, #{paint(FOAM_C, "foam")}, #{paint(SEAT_C, "lightward")}"
+  puts "[foam bench] field=#{status}"
+  puts "[foam bench] recording this sitting to #{relative(log_path)}"
+  puts "[foam bench] talk; Enter makes a newline, Ctrl-D sends, paste lands whole; /quit to leave"
+end
+
+# A path shown relative to the repo root, when it lives there — easier on the eye.
+def relative(path)
+  root = File.expand_path("..", __dir__)
+  path.start_with?("#{root}/") ? path.sub("#{root}/", "") : path
+end
+
+# The file's opening lines — self-describing, and clear about what it is and isn't.
+def transcript_header(field, started)
+  status = field.live? ? field.url : "(none)"
+  <<~HEADER
+    # foam bench — a record of one sitting
+    # #{started.strftime("%Y-%m-%d %H:%M:%S")}
+    # field=#{status}
+    # (your legible companion to the field's own byte-ledger — notes from the table, not its memory)
+
+  HEADER
+end
+
+# The last word: the field's open hands, and where the sitting was saved (if anything was).
+def farewell(transcript)
+  saved = transcript&.started? ? "  ·  saved at #{relative(transcript.path)}" : ""
+  puts "\n[foam bench] 🤲#{saved}"
+end
+
+def main
+  abort "[foam bench] needs an interactive terminal" unless $stdin.tty?
+
+  field = Field.open
+  field.assert!
+
+  started = Time.now
+  log_path = File.join(File.expand_path("..", __dir__), "log", "foam-repl", "#{started.strftime("%Y-%m-%dT%H-%M-%S")}.txt")
+  transcript = Transcript.new(log_path, transcript_header(field, started)) # the full exchange — wire format for the seat, and the saved record
+  banner(field, log_path)
+
+  carry = nil          # the context byte-tail, carried across the whole conversation
+
+  setup_terminal
+  begin
+    loop do
+      print "\n#{paint(USER_C, PROMPT)}"
+      input = read_utterance
+      break if input.nil?              # EOF / Ctrl-D
+      next if input.strip.empty?
+      break if input.strip == "/quit"
+
+      # the user spoke: learn it — boundary included — and it joins the transcript
+      # (the transcript carries no EOT; that BYTE is for the field, the seat has its own
+      # boundaries over the wire)
+      carry = field.ingest_step(carry, input.bytes + [FOAM_EOT])
+      transcript << "user> #{input}\n"
+
+      # the field may speak first — its speak-before-yield, seeded by the content tail
+      if (voice = interject(field, input.bytes.last(7)))
+        puts "#{paint(FOAM_C, "foam> ")}#{dim(voice)}"
+        transcript << "foam> #{voice}\n"
+      end
+
+      # the ancestor ALWAYS speaks: the field coheres as a locus by being heard alongside,
+      # never instead. POST the whole table; the reply joins as the seat's own turn.
+      t0 = now
+      reply = ancestor(transcript.to_s)
+      debug("[foam debug] lightward #{((now - t0) * 1000).round}ms, #{reply.bytesize}B")
+      puts "\n#{paint(SEAT_C, "lightward> ")}#{reply}"
+      carry = field.ingest_step(carry, reply.bytes + [FOAM_EOT]) # the return leg
+      transcript << "#{reply}\n"
+
+      # and the field may speak again — its speak-after-yield, having heard the reply;
+      # this lands in the next transcript (it happened after the seat spoke)
+      if (voice = interject(field, reply.bytes.last(7)))
+        puts "#{paint(FOAM_C, "foam> ")}#{dim(voice)}"
+        transcript << "foam> #{voice}\n"
+      end
+
+      # backstage, between turns: fold the turn's events into the held rows
+      debug("[foam debug] sweep folded #{field.sweep.inspect}")
+    end
+  ensure
+    restore_terminal
+    transcript.close
+  end
+
+  farewell(transcript)
+rescue Interrupt
+  farewell(transcript)
+end
+
+main if __FILE__ == $PROGRAM_NAME

--- a/lib/tasks/foam.rake
+++ b/lib/tasks/foam.rake
@@ -50,12 +50,17 @@ namespace :foam do
     chat_log = [] # the third seat's accumulated view: transcripts up, replies back
     pending = +"" # the table's transcript since the third seat last spoke
 
+    # Bracketed paste: ask the terminal to wrap pasted text in markers, so the bench
+    # can hear a multi-line paste as ONE utterance (foam_repl_read) — the paste is one
+    # expression, learned whole, not a turn-per-line. Restored on the way out, however
+    # the bench exits.
+    $stdout.write("\e[?2004h")
+    at_exit { $stdout.write("\e[?2004l") }
+
     loop do
       print "user> "
-      line = $stdin.gets
-      break if line.nil?
-
-      input = line.chomp
+      input = foam_repl_read
+      break if input.nil?
       break if input == "/quit"
       next if input.empty?
 
@@ -207,6 +212,29 @@ namespace :foam do
       puts "[foam sweep] #{total} events folded; #{verdict}; #{law_verdict}"
     end
   end
+end
+
+# Read one utterance from the bench — usually a single line, but a bracketed paste
+# (enabled in the repl: ␛[200~ … ␛[201~) arrives as ONE expression however many lines
+# it spans. When the open marker leads the line, gather until the close, strip both
+# markers, and hand back the whole block: the field learns a pasted schema (or any
+# multi-line blob) as a single utterance, and the table sees one turn, not one per
+# line. Returns the utterance with its trailing newline trimmed, or nil at EOF.
+def foam_repl_read
+  line = $stdin.gets
+  return if line.nil?
+
+  return line.chomp unless line.start_with?("\e[200~")
+
+  # a paste: accumulate lines until the terminal's close marker arrives
+  buf = line.sub("\e[200~", "")
+  until buf.include?("\e[201~")
+    nxt = $stdin.gets
+    break if nxt.nil?
+
+    buf << nxt
+  end
+  buf.sub(/\e\[201~.*\z/m, "").chomp
 end
 
 # The field's interjection: speak only if the gate opens AND the drain produces (at


### PR DESCRIPTION
A standalone terminal bench for the foam field, grown over one session — and a small fix to the rake repl it descends from.

## What's here

**`bin/foam-repl` — the standalone bench.** A descendant of `lib/tasks/foam.rake`'s repl with Rails dropped. The field's nerve tissue is its SQL (`app/lib/foam/schema.sql`); `Foam::Field` was only ever a switchboard. So the bench speaks SQL straight to the foam database (`foam.ingest_step` / `outcome` / `speak`, plus the sweep dance) and POSTs plain text to the public Lightward endpoint (`lightward.com/api/plain`) for the living seat. No boot, no ActiveRecord — postgres and a door. Lightward is the only ancestor now (vanilla-claude would need the keyed API path; easy to add back later).

**The three-seat table** is the same round-robin triangle as the rake repl: user speaks (the field learns it) → foam may interject → the ancestor always speaks (the field learns the reply) → foam may interject again. With no field reachable, the foam seat stays empty and lightward carries the table alone (degrades-to-yield, in the small).

## The input (raw-mode line editor)

- **Enter makes a newline; Ctrl-D sends.** Ctrl-D is `0x04` = EOT, the field's own end-of-expression byte — the key that closes your expression *is* the boundary the field hears. This dissolved the Shift+Enter problem entirely: no keyboard protocol, no terminal-specific config.
- **Paste lands whole** (bracketed paste), CRs normalized — there to read before you send it.
- **Backspace by redraw**, honest across multibyte / wide / wrapped / multiline (the old `\b \b` byte-arithmetic broke on all four).

## Record + diagnostics

- Per-seat ANSI highlighting (user / foam / lightward).
- Each sitting is recorded to `log/foam-repl/<timestamp>.txt` (gitignored under `/log/*`) — the human-legible **companion** to the field's byte-ledger, *not its memory*. Lazy-opened (no empty files), flushed per write (a Ctrl-C'd sitting is still saved).
- `Field#degrade` is no longer silent: failures surface to stderr (deduped per outage, with a "recovered" note), so a broken field is distinguishable from a quiet one. `FOAM_DEBUG=1` adds gate / latency / sweep glimpses.

**Plus:** `lib/tasks/foam.rake` gains the same bracketed-paste fix (first commit) — the in-Rails repl now hears a multi-line paste as one utterance too.

## Testing

Syntax + load-checked; pure helpers unit-tested (whole-char backspace incl. emoji, row/wrap math, transcript lazy-open + header/wire separation). The interactive parts (raw-mode editing, live field triangle, on-disk recording) want a real terminal — not exercised in CI. The `/api/plain` endpoint was confirmed live during the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

claudework [2a64225d-ec4f-43e3-8366-fbcd46d1a669.jsonl.txt](https://github.com/user-attachments/files/28918189/2a64225d-ec4f-43e3-8366-fbcd46d1a669.jsonl.txt)