### PR TITLE
observe-day findings: boot warm-up, and the client's address

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -204,7 +204,7 @@ class ApiController < ApplicationController
     # attributed to its admission time.
     @budget_at = Time.now.utc
     @budget_scopes = {
-      "source" => UsageBudget.scope_key("source", request.remote_ip, at: @budget_at),
+      "source" => UsageBudget.scope_key("source", budget_source_value, at: @budget_at),
       "conversation" => UsageBudget.scope_key("conversation", conversation_id, at: @budget_at),
     }.compact
 
@@ -216,6 +216,14 @@ class ApiController < ApplicationController
   def budget_exempt_client?
     client = reported_usage_client
     client.present? && configured_external_usage_clients.value?(client)
+  end
+
+  # Fly's proxy sets Fly-Client-IP authoritatively on every proxied request.
+  # Behind it, remote_ip resolves to a shared edge address — which would fold
+  # every visitor into one source budget. Fall back to remote_ip off-Fly
+  # (development, test).
+  def budget_source_value
+    request.headers["Fly-Client-IP"].presence || request.remote_ip
   end
 
   # Settle the admission made in check_usage_budget!: fold in the actual

--- a/app/lib/usage_budget.rb
+++ b/app/lib/usage_budget.rb
@@ -171,6 +171,15 @@ module UsageBudget
       }
     end
 
+    # Establish the client and its connection ahead of need (e.g. at boot,
+    # before the machine accepts traffic) so the first budgeted request never
+    # pays the connect — or races boot-time CPU for it. Fail-open like
+    # everything else: an unreachable store costs one bounded timeout here
+    # and nothing more. Returns truthy on success, nil otherwise.
+    def warm!
+      with_redis(&:ping)
+    end
+
     # Seconds until the earliest window that could clear the verdict rolls
     # over — the next UTC hour unless only a per-day dimension is exceeded.
     def retry_after_seconds(verdict)

--- a/config/initializers/usage_budget.rb
+++ b/config/initializers/usage_budget.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Warm the budget store connection at the tail of boot, off the request
+# path: a machine finishes booting already connected, so its first budgeted
+# request never races boot-time CPU for the connect (the source of
+# cold-start "untracked" noise on auto-started machines). Fail-open like
+# everything else — an unreachable store costs one bounded timeout here and
+# nothing more.
+#
+# Safe without preload_app!: each worker boots the app after fork, so this
+# runs in the process that will use the connection. Skipped in test (the
+# suite stays hermetic) and when budgets are off (inert means inert — no
+# boot-time dial for a store nothing will consult).
+Rails.application.config.after_initialize do
+  UsageBudget.warm! if UsageBudget.active? && !Rails.env.test?
+end

--- a/spec/lib/usage_budget_spec.rb
+++ b/spec/lib/usage_budget_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe(UsageBudget, :aggregate_failures) do
       expect(described_class.settle!({ "source" => "abc123" }, cost_usd: 0.01)).to(be_nil)
     end
 
+    it "warm! is fail-open too: nil when unconfigured or unreachable" do
+      expect(described_class.warm!).to(be_nil)
+
+      configure_store!("redis://127.0.0.1:1")
+      expect(described_class.warm!).to(be_nil)
+    end
+
     it "opens a breaker after a failure so the store is not re-dialed per request" do
       configure_store!("redis://127.0.0.1:1")
 
@@ -317,6 +324,7 @@ RSpec.describe(UsageBudget, :aggregate_failures) do
       expect(client.hget(hour_key, "cost").to_f).to(be_within(0.0001).of(0.05))
       expect(client.ttl(hour_key)).to(be_between(1, UsageBudget::TTL_SECONDS["hour"]))
 
+      expect(described_class.warm!).to(be_truthy)
       expect(described_class.refund!(scopes, at: at)).to(be(true))
       expect(client.hget(hour_key, "requests")).to(eq("2"))
       client.close

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -625,6 +625,22 @@ RSpec.describe("API", type: :request) do
             at: kind_of(Time),
           ))
         end
+
+        it "scopes the source by Fly-Client-IP when the proxy provides it", :aggregate_failures do
+          admitted_scopes = nil
+          allow(UsageBudget).to(receive(:admit!)) do |scopes, **|
+            admitted_scopes = scopes
+            UsageBudget::Verdict.new(over_dimensions: [])
+          end
+          allow(UsageBudget).to(receive(:settle!))
+
+          post "/api/stream",
+            params: { chat_log: chat_log, usage_client: "reader" },
+            headers: { "Fly-Client-IP" => "203.0.113.7" }
+
+          expect(admitted_scopes["source"]).to(eq(UsageBudget.scope_key("source", "203.0.113.7")))
+          expect(admitted_scopes["source"]).not_to(eq(UsageBudget.scope_key("source", "127.0.0.1")))
+        end
       end
 
       context "with enforce mode configured" do


### PR DESCRIPTION
Two findings from the budget layer's first observed hours in production, each small, each the kind of thing only live traffic reveals.

**1. Warm the store connection at boot.** Auto-started machines serve their first request while still CPU-busy from boot, and the budget connect loses that race — one `untracked` per machine start, bounded by the breaker and fail-open (harmless), but permanent background noise in the health signal an operator watches. Measured from inside production: the full connect+handshake is 13–36ms warm — the store was never slow; the machine was busy. Fix: one PING at the tail of boot, before the machine accepts traffic, guarded to run only when budgets are active (inert means inert).

**2. Scope sources by the client's address, not the proxy's.** Behind Fly's proxy, `request.remote_ip` resolves to a shared edge address — three hours of telemetry showed thirteen conversations living at two "sources". Every visitor was folding into one source budget, which in enforce mode would have paced everyone together the moment the aggregate crossed a line meant for one actor. Fix: read `Fly-Client-IP` (set authoritatively by Fly's proxy on every proxied request), falling back to `remote_ip` off-Fly. Same HMAC, same day-salt, same privacy — just the right address going in.

The second finding is a prerequisite for switching `LAI_BUDGET_MODE` to enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)