### PR TITLE
fly secrets: the budget config joins the declared list

### DIFF
--- a/.github/workflows/fly-secrets.yml
+++ b/.github/workflows/fly-secrets.yml
@@ -29,10 +29,25 @@ jobs:
             stage_flag="--stage"
           fi
           # TOKEN_LIMIT_BYPASS_KEYS accepts comma-separated values for multiple client keys
+          # LAI_BUDGET_*: shared-resource budget config — the store URL is a secret
+          # (it embeds credentials); mode/timeout/thresholds are vars (operational
+          # tuning). Empty values are safe: no mode means off, no threshold means
+          # that dimension is unbounded, no URL means the store is inert (fail-open).
           flyctl secrets set \
             $stage_flag \
             --app ${{ vars.FLY_APP_NAME }} \
             ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}" \
+            LAI_BUDGET_MODE="${{ vars.LAI_BUDGET_MODE }}" \
+            LAI_BUDGET_REDIS_URL="${{ secrets.LAI_BUDGET_REDIS_URL }}" \
+            LAI_BUDGET_TIMEOUT_SECONDS="${{ vars.LAI_BUDGET_TIMEOUT_SECONDS }}" \
+            LAI_BUDGET_CONVERSATION_REQUESTS_PER_HOUR="${{ vars.LAI_BUDGET_CONVERSATION_REQUESTS_PER_HOUR }}" \
+            LAI_BUDGET_CONVERSATION_REQUESTS_PER_DAY="${{ vars.LAI_BUDGET_CONVERSATION_REQUESTS_PER_DAY }}" \
+            LAI_BUDGET_CONVERSATION_COST_PER_HOUR_USD="${{ vars.LAI_BUDGET_CONVERSATION_COST_PER_HOUR_USD }}" \
+            LAI_BUDGET_CONVERSATION_COST_PER_DAY_USD="${{ vars.LAI_BUDGET_CONVERSATION_COST_PER_DAY_USD }}" \
+            LAI_BUDGET_SOURCE_REQUESTS_PER_HOUR="${{ vars.LAI_BUDGET_SOURCE_REQUESTS_PER_HOUR }}" \
+            LAI_BUDGET_SOURCE_REQUESTS_PER_DAY="${{ vars.LAI_BUDGET_SOURCE_REQUESTS_PER_DAY }}" \
+            LAI_BUDGET_SOURCE_COST_PER_HOUR_USD="${{ vars.LAI_BUDGET_SOURCE_COST_PER_HOUR_USD }}" \
+            LAI_BUDGET_SOURCE_COST_PER_DAY_USD="${{ vars.LAI_BUDGET_SOURCE_COST_PER_DAY_USD }}" \
             LAI_REPORTED_USAGE_CLIENTS="${{ vars.LAI_REPORTED_USAGE_CLIENTS }}" \
             TOKEN_LIMIT_BYPASS_KEYS="${{ secrets.TOKEN_LIMIT_BYPASS_KEYS }}" \
             HOST="${{ vars.HOST }}" \


### PR DESCRIPTION
The `LAI_BUDGET_*` runtime config was set by hand during the budget rollout; this threads it through the same pipeline as everything else — GitHub environment secrets/vars, staged to Fly on every deploy — so a rebuild or rotation reproduces it, and staging can opt in by setting its own values.

The store URL rides as a **secret** (it embeds credentials); mode, timeout, and thresholds are **vars**. Empty values are safe by the layer's own semantics: no mode means off, no threshold means unbounded, no URL means the store is inert (fail-open).

**Before merging:** the production environment needs `LAI_BUDGET_REDIS_URL` added as a GitHub secret (the ten vars are already set) — otherwise the next deploy stages an empty URL over the hand-set one and budgets quietly go inert. One command:

```
gh secret set LAI_BUDGET_REDIS_URL -e production
```

Staging values are intentionally unset for now: budgets stay off there until someone wants them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)