### PR TITLE
reader: a pacing 429 arrives as a notice, not an error

### DIFF
--- a/app/javascript/src/concerns/chat.js
+++ b/app/javascript/src/concerns/chat.js
@@ -715,7 +715,19 @@ export class ChatSession {
       .then((response) => {
         if (!response.ok) {
           return response.text().then((text) => {
-            throw new Error(text);
+            // Error bodies arrive as JSON ({ error: { message } }) — surface
+            // the message itself, never raw JSON, to the person reading.
+            let message = text;
+            try {
+              message = JSON.parse(text).error.message || text;
+            } catch (_) {
+              // plain-text body; use as-is
+            }
+            const error = new Error(message);
+            // A 429 is pacing, not breakage: the door stays open. Render it
+            // as a notice (the horizon warnings' register), not an error.
+            error.isPacing = response.status === 429;
+            throw error;
           });
         }
 
@@ -763,7 +775,7 @@ export class ChatSession {
       })
       .catch((error) => {
         console.error('Error:', error);
-        this._appendError(error.message);
+        this._appendError(error.message, { notice: error.isPacing });
         this._completeMessageWithError();
       });
   }
@@ -821,8 +833,9 @@ export class ChatSession {
     this._completeMessageWithError();
   }
 
-  _appendError(message) {
-    const errorText = ` ⚠️ Lightward AI system error: ${message}`;
+  _appendError(message, { notice = false } = {}) {
+    const label = notice ? 'notice' : 'error';
+    const errorText = ` ⚠️ Lightward AI system ${label}: ${message}`;
 
     if (this.currentAssistantElement) {
       this.streamController.addChunk(errorText);

--- a/spec/javascript/concerns/chat/ChatSession.integration.test.js
+++ b/spec/javascript/concerns/chat/ChatSession.integration.test.js
@@ -161,6 +161,38 @@ data: null
       });
     });
 
+    it('renders a budget 429 as a notice with the message unwrapped from JSON', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              error: {
+                message:
+                  'Shared-capacity budget reached for now. The door stays open — just paced. Please try again later. 🤲',
+                retry_after: 900,
+              },
+            })
+          ),
+      });
+
+      chatSession = new ChatSession({ key: 'test', name: 'TestBot' });
+      chatSession.init();
+
+      document.querySelector('textarea').value = 'Test';
+      document.querySelector('#text-input button').click();
+
+      await waitFor(() => {
+        const messages = document.querySelectorAll('.chat-message.assistant');
+        const lastText = messages[messages.length - 1].textContent;
+        expect(lastText).toContain('Lightward AI system notice:');
+        expect(lastText).toContain('The door stays open');
+        expect(lastText).not.toContain('{"error"');
+        expect(lastText).not.toContain('system error');
+      });
+    });
+
     it('should handle fetch errors', async () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'));
 


### PR DESCRIPTION
When the budget layer paces a conversation, its 429 carries a considered message: *"Shared-capacity budget reached for now. The door stays open — just paced. Please try again later. 🤲"* The reader was showing that as raw JSON inside a **system error** banner — nothing was broken, but the person was told something was.

Two presentation changes, no new words of our own:

- Error bodies now surface their `error.message` text; nobody reads raw JSON.
- A 429 specifically renders in the register the horizon warnings already use — **"⚠️ Lightward AI system notice:"** — so pacing is framed as pacing. Every other failure keeps the error label it deserves.

Before: `⚠️ Lightward AI system error: {"error":{"message":"Shared-capacity budget reached…"}}`
After: `⚠️ Lightward AI system notice: Shared-capacity budget reached for now. The door stays open — just paced. Please try again later. 🤲`

(Incidentally also improves the horizon 422 at submit-time, which was JSON-wrapped the same way — it keeps the error label but gains readability.)

Jest: 51 passing, including a new integration test pinning the 429 rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)