### PR TITLE
prompt cache: the corpus keeps for an hour

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -17,6 +17,13 @@ class ApiController < ApplicationController
     "cache_creation_input_tokens",
     "cache_read_input_tokens",
   ].freeze
+  # Cache writes bill by TTL tier (5m at 1.25x base, 1h at 2x); the API
+  # reports the split under usage.cache_creation. Captured flattened, so
+  # cost accounting can price each tier at its own rate.
+  ANTHROPIC_CACHE_CREATION_KEYS = {
+    "ephemeral_5m_input_tokens" => "cache_creation_5m_input_tokens",
+    "ephemeral_1h_input_tokens" => "cache_creation_1h_input_tokens",
+  }.freeze
   TELEMETRY_HMAC_NAMESPACE = "lai-usage-telemetry-v1"
   BUDGET_EXCEEDED_MESSAGE = "Shared-capacity budget reached for now. The door stays open — just paced. Please try again later. 🤲"
 
@@ -392,6 +399,8 @@ class ApiController < ApplicationController
       input_tokens: normalized_usage["input_tokens"],
       output_tokens: normalized_usage["output_tokens"],
       cache_creation_input_tokens: normalized_usage["cache_creation_input_tokens"],
+      cache_creation_5m_input_tokens: normalized_usage["cache_creation_5m_input_tokens"],
+      cache_creation_1h_input_tokens: normalized_usage["cache_creation_1h_input_tokens"],
       cache_read_input_tokens: normalized_usage["cache_read_input_tokens"],
       estimated_cost_usd: estimated_cost_usd(normalized_usage),
       budget_state: budget_state,
@@ -428,14 +437,37 @@ class ApiController < ApplicationController
       usage[key] = anthropic_usage[key] if anthropic_usage.key?(key)
     end
 
+    # Non-streaming responses carry the nested cache_creation object; the
+    # streaming path has already flattened it in capture_anthropic_usage!.
+    breakdown = anthropic_usage["cache_creation"]
+    ANTHROPIC_CACHE_CREATION_KEYS.each do |api_key, flat_key|
+      if anthropic_usage.key?(flat_key)
+        usage[flat_key] = anthropic_usage[flat_key]
+      elsif breakdown.is_a?(Hash) && breakdown.key?(api_key)
+        usage[flat_key] = breakdown[api_key]
+      end
+    end
+
     usage
   end
 
   def estimated_cost_usd(anthropic_usage)
     return if anthropic_usage.values.all?(&:nil?)
 
+    usage = anthropic_usage.dup
+    if usage["cache_creation_5m_input_tokens"] || usage["cache_creation_1h_input_tokens"]
+      # The per-TTL breakdown is authoritative; drop the aggregate so the
+      # same tokens aren't priced twice.
+      usage.delete("cache_creation_input_tokens")
+    else
+      # No breakdown reported: price the aggregate at the 1-hour rate — the
+      # system prompt (the overwhelming share of any write) uses that tier,
+      # and overcounting is the safe direction for budget enforcement.
+      usage["cache_creation_1h_input_tokens"] = usage.delete("cache_creation_input_tokens")
+    end
+
     cost = Prompts::Anthropic::PRICING_USD_PER_MILLION.sum { |key, usd_per_million|
-      anthropic_usage[key].to_i * usd_per_million / 1_000_000.0
+      usage[key].to_i * usd_per_million / 1_000_000.0
     }
 
     cost.round(8)
@@ -484,6 +516,13 @@ class ApiController < ApplicationController
 
     ANTHROPIC_USAGE_TOKEN_KEYS.each do |key|
       anthropic_usage[key] = usage[key] if usage.key?(key)
+    end
+
+    breakdown = usage["cache_creation"]
+    if breakdown.is_a?(Hash)
+      ANTHROPIC_CACHE_CREATION_KEYS.each do |api_key, flat_key|
+        anthropic_usage[flat_key] = breakdown[api_key] if breakdown.key?(api_key)
+      end
     end
   end
 

--- a/app/lib/prompts.rb
+++ b/app/lib/prompts.rb
@@ -257,7 +257,11 @@ module Prompts
       # cache the longest matching prefix from all previous messages.
       result = messages.map { |m| m.except(:size) }
 
-      # Add cache_control to the last message only
+      # Add cache_control to the last message only. The TTL is deliberately
+      # NOT set here: this array is served verbatim at /api/system.json for
+      # anyone to reuse, and cache-lifetime economics belong to whoever pays
+      # for the request. Our own TTL choice is applied at the transport
+      # layer (Prompts::Anthropic) just before the API call.
       result.last[:cache_control] = { type: "ephemeral" } unless result.empty?
 
       result.map(&:freeze)

--- a/app/lib/prompts/anthropic.rb
+++ b/app/lib/prompts/anthropic.rb
@@ -11,10 +11,25 @@ module Prompts
     ORIGIN = "https://api.anthropic.com"
     MODEL = "claude-sonnet-4-6"
     BETAS = nil
-    # Claude Sonnet 4.6 API pricing, checked against Anthropic docs on 2026-06-06.
+    # Our cache lifetime for the system prompt, applied here at the transport
+    # layer — NOT in the published prompt itself, which /api/system.json
+    # serves verbatim to third parties whose traffic economics are their own.
+    # The 1-hour tier (GA, no beta header) costs 2x base per write vs 1.25x
+    # for the 5-minute default, and reads (which dominate for us) cost the
+    # same either way; it pays for itself whenever it saves rewrites across
+    # the gaps in traffic. Cached entries refresh on every read at no cost.
+    # Client-submitted markers in the chat_log stay on the 5-minute default
+    # (the controller strips any client-sent ttl), which also satisfies the
+    # API's longer-TTL-first ordering rule, since system renders first.
+    CACHE_TTL = "1h"
+    # Claude Sonnet 4.6 API pricing, checked against Anthropic docs on
+    # 2026-07-09. Cache writes bill by TTL tier: 1.25x base for the 5-minute
+    # default, 2x for the 1-hour tier used on the system prompt. The API
+    # reports the split under usage.cache_creation.ephemeral_{5m,1h}_input_tokens.
     PRICING_USD_PER_MILLION = {
       "input_tokens" => 3.0,
-      "cache_creation_input_tokens" => 3.75,
+      "cache_creation_5m_input_tokens" => 3.75,
+      "cache_creation_1h_input_tokens" => 6.0,
       "cache_read_input_tokens" => 0.30,
       "output_tokens" => 15.0,
     }.freeze
@@ -50,11 +65,29 @@ module Prompts
           max_tokens: 4000,
           stream: stream,
           temperature: 1.0,
-          system: system,
+          system: apply_cache_ttl(system),
           messages: messages,
         }
 
         api_request("/v1/messages", payload, &block)
+      end
+
+      # Merge CACHE_TTL into any cache_control markers in the system blocks.
+      # Applied only on this billable path — count_tokens writes no cache,
+      # and the published /api/system.json stays TTL-neutral.
+      def apply_cache_ttl(system)
+        return system unless system.respond_to?(:map)
+
+        system.map do |block|
+          key = if block.key?(:cache_control)
+            :cache_control
+          elsif block.key?("cache_control")
+            "cache_control"
+          end
+          next block unless key
+
+          block.merge(key => block[key].merge(ttl: CACHE_TTL))
+        end
       end
 
       def api_request(path, payload)

--- a/spec/lib/prompts_spec.rb
+++ b/spec/lib/prompts_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe(Prompts, :aggregate_failures) do
         expect(cache_control_count).to(eq(1))
         expect(system_messages.last).to(have_key(:cache_control))
       end
+
+      it "publishes a TTL-neutral marker (cache lifetime is transport policy, applied in Prompts::Anthropic)" do
+        expect(system_messages.last[:cache_control]).to(eq({ type: "ephemeral" }))
+      end
     end
   end
 

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe("API", type: :request) do
       built = Prompts.build_system_prompt.map { |m| JSON.parse(m.to_json) }
 
       expect(served).to(eq(built))
+      # Pinned literally (not just round-tripped) so any change to the
+      # published marker shape is a deliberate, reviewed decision: this is a
+      # public integration surface third parties copy. TTL-neutral on purpose.
+      expect(served.last["cache_control"]).to(eq({ "type" => "ephemeral" }))
     end
 
     it "serves the system prompt as plain text", :aggregate_failures do
@@ -75,6 +79,40 @@ RSpec.describe("API", type: :request) do
 
       expect(response).to(have_http_status(:ok))
       expect(response.headers["Content-Type"]).to(eq("text/event-stream"))
+    end
+
+    it "applies the 1h cache TTL to the system prompt at the transport layer, and strips client-sent ttl", :aggregate_failures do
+      allow(Prompts).to(receive(:generate_system_prompt).and_return([
+        { type: "text", text: "test system prompt", cache_control: { type: "ephemeral" } },
+      ]))
+
+      ttl_chat_log = [
+        {
+          role: "user",
+          content: [
+            # A client copying the served marker shape must not be able to buy
+            # a 1h write on its own never-shared prefix: ttl is stripped.
+            { type: "text", text: "Warmup", cache_control: { type: "ephemeral", ttl: "1h" } },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Hello!" }],
+        },
+      ]
+
+      post "/api/stream", params: { chat_log: ttl_chat_log }
+
+      expect(a_request(:post, "https://api.anthropic.com/v1/messages").with { |req|
+        body = JSON.parse(req.body)
+        # clean_chat_log merges the two consecutive user messages into one,
+        # so both text blocks live in the first message's content array.
+        system_marker = body["system"].last["cache_control"]
+        client_marker = body["messages"].dig(0, "content", 0, "cache_control")
+
+        system_marker == { "type" => "ephemeral", "ttl" => "1h" } &&
+          client_marker == { "type" => "ephemeral" }
+      }).to(have_been_made.once)
     end
 
     context "when chat log exceeds token limit" do
@@ -477,13 +515,13 @@ RSpec.describe("API", type: :request) do
         ))
       end
 
-      it "records streaming Anthropic usage and estimated cost" do
+      it "records streaming Anthropic usage and estimated cost, pricing cache writes by TTL tier" do
         stub_request(:post, "https://api.anthropic.com/v1/messages")
           .to_return(
             status: 200,
             body: [
               "event: message_start",
-              'data: {"type":"message_start","message":{"usage":{"input_tokens":1000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":3000,"output_tokens":1}}}',
+              'data: {"type":"message_start","message":{"usage":{"input_tokens":1000,"cache_creation_input_tokens":2000,"cache_creation":{"ephemeral_5m_input_tokens":500,"ephemeral_1h_input_tokens":1500},"cache_read_input_tokens":3000,"output_tokens":1}}}',
               "",
               "event: message_delta",
               'data: {"type":"message_delta","usage":{"output_tokens":400}}',
@@ -497,6 +535,8 @@ RSpec.describe("API", type: :request) do
 
         post "/api/stream", params: { chat_log: chat_log, usage_client: "writer" }
 
+        # 1000 input @ $3 + 500 5m-writes @ $3.75 + 1500 1h-writes @ $6
+        # + 3000 reads @ $0.30 + 400 output @ $15, per million tokens.
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
           hash_including(
@@ -505,8 +545,10 @@ RSpec.describe("API", type: :request) do
             input_tokens: 1000,
             output_tokens: 400,
             cache_creation_input_tokens: 2000,
+            cache_creation_5m_input_tokens: 500,
+            cache_creation_1h_input_tokens: 1500,
             cache_read_input_tokens: 3000,
-            estimated_cost_usd: 0.0174,
+            estimated_cost_usd: 0.020775,
           ),
         ))
       end
@@ -616,12 +658,15 @@ RSpec.describe("API", type: :request) do
 
           post "/api/stream", params: { chat_log: chat_log, usage_client: "reader" }
 
+          # This stub reports no per-TTL breakdown, so the aggregate write
+          # count is priced at the 1-hour tier — overcounting is the safe
+          # direction for budget enforcement.
           expect(UsageBudget).to(have_received(:settle!).with(
             {
               "source" => UsageBudget.scope_key("source", "127.0.0.1"),
               "conversation" => UsageBudget.scope_key("conversation", Digest::SHA256.hexdigest(chat_log.to_json)),
             },
-            cost_usd: 0.0174,
+            cost_usd: 0.0219,
             at: kind_of(Time),
           ))
         end
@@ -1120,7 +1165,7 @@ RSpec.describe("API", type: :request) do
         ))
       end
 
-      it "records plain Anthropic usage and estimated cost" do
+      it "records plain Anthropic usage and estimated cost, flattening the cache_creation breakdown" do
         stub_request(:post, "https://api.anthropic.com/v1/messages")
           .to_return(
             status: 200,
@@ -1131,6 +1176,10 @@ RSpec.describe("API", type: :request) do
                 input_tokens: 10,
                 output_tokens: 20,
                 cache_creation_input_tokens: 30,
+                cache_creation: {
+                  ephemeral_5m_input_tokens: 10,
+                  ephemeral_1h_input_tokens: 20,
+                },
                 cache_read_input_tokens: 40,
               },
             }.to_json,
@@ -1139,14 +1188,19 @@ RSpec.describe("API", type: :request) do
 
         post "/api/plain", params: "Hello", headers: { "CONTENT_TYPE" => "text/plain" }
 
+        # 10 input @ $3 + 10 5m-writes @ $3.75 + 20 1h-writes @ $6
+        # + 40 reads @ $0.30 + 20 output @ $15, per million tokens:
+        # (30 + 37.5 + 120 + 12 + 300) / 1e6.
         expect(NewRelic::Agent).to(have_received(:record_custom_event).with(
           "ApiController: request",
           hash_including(
             input_tokens: 10,
             output_tokens: 20,
             cache_creation_input_tokens: 30,
+            cache_creation_5m_input_tokens: 10,
+            cache_creation_1h_input_tokens: 20,
             cache_read_input_tokens: 40,
-            estimated_cost_usd: 0.0004545,
+            estimated_cost_usd: 0.0004995,
           ),
         ))
       end

--- a/spec/requests/meta_spec.rb
+++ b/spec/requests/meta_spec.rb
@@ -37,6 +37,9 @@ RSpec.describe("meta", type: :request) do
       expect(parsed).to(be_an(Array))
       expect(parsed.first).to(include("type" => "text"))
       expect(parsed.second["text"]).to(include("hey, good morning"))
+      # The published marker stays TTL-neutral: /api/system.json is a public
+      # integration surface, and cache-lifetime economics belong to whoever
+      # pays for the request. Our TTL is applied at the transport layer.
       expect(parsed.last).to(include("cache_control" => { "type" => "ephemeral" }))
     end
   end


### PR DESCRIPTION
The corpus dominates our Anthropic bill, and most of the *write* cost comes from re-caching it after the five-minute TTL lapses in ordinary traffic gaps. A week of production timestamps, simulated against both TTLs, showed the one-hour tier eliminating nearly all of those rewrites — cached entries refresh on every read at no cost, so steady traffic keeps the hour alive indefinitely. Hour-long writes bill at 2× base instead of 1.25×, and reads (which dominate for us) cost the same either way; the tier pays for itself whenever it saves rewrites across traffic gaps, which our traffic shape does constantly.

**Where the TTL lives matters as much as what it is.** It's applied at the transport layer (`Prompts::Anthropic`), just before the API call — *not* in the published prompt. `/api/system.json` serves the corpus verbatim to third parties whose traffic economics are their own; the served marker stays a TTL-neutral `{type: "ephemeral"}`, now pinned literally by spec so any change to that public shape is a deliberate, reviewed decision.

**Cost accounting learns the two write tiers.** The API reports the split under `usage.cache_creation` (`ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens`); the controller captures both (streaming and plain paths), prices each at its own rate, and records them to New Relic alongside the aggregate. When no breakdown is reported, the aggregate falls back to the 1-hour rate — overcounting is the safe direction for budget enforcement.

**Client markers stay on the five-minute default.** Strong params already stripped any client-sent `ttl`; that invariant is now pinned by a request spec asserting the outbound `/v1/messages` body carries `ttl: "1h"` on the system prompt and a plain marker on the client's block. This also satisfies the API's longer-TTL-first ordering, since system renders first.

**Verification.** Two independent adversarial review passes over the final diff came back with zero confirmed findings — including empirical checks that merging the ttl into the deep-frozen memoized prompt neither raises nor leaks back into the published payload, mutation-testing that each new spec fails loudly when the behavior it pins is broken, and hand-recomputation of every expected cost value. The one open question (does the 1-hour tier still require a beta header?) was closed with a live smoke request against the production API: this exact payload shape, no beta header, returned 200, with the response usage carrying the same `cache_creation` breakdown the controller now parses.

Remaining, post-merge: verify the live token mix a day after deploy (cache reads stay high, write spend drops), and add a New Relic alert on cache-read collapse — the same observe-then-trust discipline as the budget layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
