### PR TITLE
prompt cache: the conversation keeps too

### DIFF
--- a/app/lib/prompts/anthropic.rb
+++ b/app/lib/prompts/anthropic.rb
@@ -66,7 +66,7 @@ module Prompts
           stream: stream,
           temperature: 1.0,
           system: apply_cache_ttl(system),
-          messages: messages,
+          messages: cache_conversation_tail(messages),
         }
 
         api_request("/v1/messages", payload, &block)
@@ -88,6 +88,44 @@ module Prompts
 
           block.merge(key => block[key].merge(ttl: CACHE_TTL))
         end
+      end
+
+      # Add a cache breakpoint at the very end of the conversation, so each
+      # turn writes only its new suffix and reads the rest back at the
+      # cache-read rate instead of re-sending the whole history as
+      # full-price input. Like apply_cache_ttl, this is transport policy on
+      # the billable path only.
+      #
+      # The client's own marker stays exactly where the client put it: its
+      # position is semantic, not economic — it marks the end of the
+      # conversation frame, and conversation identity is derived from it
+      # upstream. This only adds a breakpoint; it never moves or removes one.
+      #
+      # Requests with no marker anywhere (one-shot /api/plain traffic) are
+      # left untouched: content that will never be re-sent gains nothing
+      # from caching and shouldn't pay the write premium for it.
+      def cache_conversation_tail(messages)
+        return messages unless messages.is_a?(Array)
+        return messages unless messages.any? { |msg| message_has_cache_marker?(msg) }
+
+        last = messages.last
+        content_key = key_in(last, :content)
+        content = content_key && last[content_key]
+        return messages unless content.is_a?(Array)
+
+        tail = content.last
+        return messages unless tail.is_a?(Hash)
+        return messages if key_in(tail, :cache_control)
+
+        marker = if tail.key?(:type)
+          { cache_control: { type: "ephemeral" } }
+        else
+          { "cache_control" => { "type" => "ephemeral" } }
+        end
+
+        messages[0...-1] + [
+          last.merge(content_key => content[0...-1] + [tail.merge(marker)]),
+        ]
       end
 
       def api_request(path, payload)
@@ -119,6 +157,24 @@ module Prompts
       end
 
       private
+
+      def message_has_cache_marker?(msg)
+        return false unless msg.is_a?(Hash)
+
+        content_key = key_in(msg, :content)
+        content = content_key && msg[content_key]
+        return false unless content.is_a?(Array)
+
+        content.any? { |block| block.is_a?(Hash) && key_in(block, :cache_control) }
+      end
+
+      def key_in(hash, key)
+        if hash.key?(key)
+          key
+        elsif hash.key?(key.to_s)
+          key.to_s
+        end
+      end
 
       def build_anthropic_request(uri, payload)
         headers = {

--- a/spec/lib/prompts/anthropic_spec.rb
+++ b/spec/lib/prompts/anthropic_spec.rb
@@ -61,6 +61,84 @@ RSpec.describe(Prompts::Anthropic, :aggregate_failures) do
     end
   end
 
+  describe ".cache_conversation_tail" do
+    let(:marked_log) do
+      [
+        {
+          "role" => "user",
+          "content" => [
+            { "type" => "text", "text" => "frame", "cache_control" => { "type" => "ephemeral" } },
+            { "type" => "text", "text" => "hello" },
+          ],
+        },
+        {
+          "role" => "assistant",
+          "content" => [{ "type" => "text", "text" => "hi" }],
+        },
+        {
+          "role" => "user",
+          "content" => [{ "type" => "text", "text" => "more" }],
+        },
+      ]
+    end
+
+    it "adds a breakpoint to the final content block when the client opted into caching" do
+      result = described_class.cache_conversation_tail(marked_log)
+
+      expect(result.last["content"].last["cache_control"]).to(eq({ "type" => "ephemeral" }))
+    end
+
+    it "leaves the client's own marker exactly where it was" do
+      result = described_class.cache_conversation_tail(marked_log)
+
+      expect(result.first["content"].first["cache_control"]).to(eq({ "type" => "ephemeral" }))
+      expect(result.first["content"].second).not_to(have_key("cache_control"))
+    end
+
+    it "does not mutate the input" do
+      described_class.cache_conversation_tail(marked_log)
+
+      expect(marked_log.last["content"].last).not_to(have_key("cache_control"))
+    end
+
+    it "handles symbol keys" do
+      log = [
+        { role: "user", content: [{ type: "text", text: "frame", cache_control: { type: "ephemeral" } }] },
+        { role: "user", content: [{ type: "text", text: "more" }] },
+      ]
+
+      result = described_class.cache_conversation_tail(log)
+
+      expect(result.last[:content].last[:cache_control]).to(eq({ type: "ephemeral" }))
+    end
+
+    it "leaves marker-less logs untouched (one-shot traffic shouldn't pay the write premium)" do
+      log = [{ "role" => "user", "content" => [{ "type" => "text", "text" => "hello" }] }]
+
+      expect(described_class.cache_conversation_tail(log)).to(equal(log))
+    end
+
+    it "adds nothing when the final block already carries the marker" do
+      log = [
+        {
+          "role" => "user",
+          "content" => [{ "type" => "text", "text" => "hi", "cache_control" => { "type" => "ephemeral" } }],
+        },
+      ]
+
+      expect(described_class.cache_conversation_tail(log)).to(equal(log))
+    end
+
+    it "leaves string-content messages untouched (no block to attach a marker to)" do
+      log = [
+        { "role" => "user", "content" => [{ "type" => "text", "text" => "a", "cache_control" => { "type" => "ephemeral" } }] },
+        { "role" => "user", "content" => "plain string" },
+      ]
+
+      expect(described_class.cache_conversation_tail(log)).to(equal(log))
+    end
+  end
+
   describe ".count_tokens" do
     let(:messages) { [{ "role" => "user", "content" => [{ "type" => "text", "text" => "Hello world" }] }] }
 

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -109,9 +109,35 @@ RSpec.describe("API", type: :request) do
         # so both text blocks live in the first message's content array.
         system_marker = body["system"].last["cache_control"]
         client_marker = body["messages"].dig(0, "content", 0, "cache_control")
+        # The transport layer adds its own breakpoint on the final block, so
+        # each turn writes only its new suffix and reads the history back.
+        tail_marker = body["messages"].dig(-1, "content", -1, "cache_control")
 
         system_marker == { "type" => "ephemeral", "ttl" => "1h" } &&
-          client_marker == { "type" => "ephemeral" }
+          client_marker == { "type" => "ephemeral" } &&
+          tail_marker == { "type" => "ephemeral" }
+      }).to(have_been_made.once)
+    end
+
+    it "adds no cache markers to marker-less one-shot requests", :aggregate_failures do
+      stub_request(:post, "https://api.anthropic.com/v1/messages")
+        .to_return(
+          status: 200,
+          body: {
+            content: [{ type: "text", text: "Hello!" }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 10, output_tokens: 5 },
+          }.to_json,
+          headers: { "Content-Type" => "application/json" },
+        )
+
+      post "/api/plain", params: "Hello", headers: { "CONTENT_TYPE" => "text/plain" }
+
+      expect(a_request(:post, "https://api.anthropic.com/v1/messages").with { |req|
+        body = JSON.parse(req.body)
+        # One-shot content is never re-sent; caching it would be pure write
+        # premium with no read to pay it back.
+        body["messages"].flat_map { |m| m["content"] }.none? { |b| b.key?("cache_control") }
       }).to(have_been_made.once)
     end
 


### PR DESCRIPTION
Follow-on to #2114, closing the last mechanical gap in cache coverage: conversation history.

**The gap.** The client's chat_log carries exactly one cache marker, at the end of the conversation frame. That position is *semantic* — conversation identity is derived from it — but it was also doing double duty as the only cache breakpoint, so everything after the frame (the actual back-and-forth) was re-sent as full-price input on every turn. A conversation pays for its own history once per message, forever.

**The fix, at the same altitude as the TTL.** `Prompts::Anthropic` now adds its own breakpoint on the final content block of the conversation, on the billable path only. Each turn writes just its new suffix at the modest write premium, and reads everything before it back at the cache-read rate. Measured over two days of production traffic: most follow-up messages arrive well inside the cache lifetime, and long conversations — where the tokens live — skew fastest, so the expected cost of history lands well under half of what it is today, with the slow-conversation downside bounded at the write premium.

**What deliberately doesn't change:**
- The client's own marker stays exactly where the client put it. Its position defines the conversation frame upstream; the transport layer never moves or removes a marker, only adds one.
- Marker-less one-shot requests (`/api/plain`) are untouched — content that will never be re-sent gains nothing from caching and shouldn't pay a write premium for it.
- The tail breakpoint stays on the default cache lifetime; only the system prompt carries the 1-hour TTL, which also keeps the API's longer-TTL-first ordering satisfied.
- The published `/api/system.json` and the client contract (one marker, `ttl` stripped) are exactly as pinned in #2114.

Specs pin the outbound request shape (frame marker in place, tail marker added, one-shots untouched) plus unit coverage for the edge cases (already-marked tails, string content, symbol/string keys, input immutability).

**Verification.** Two independent adversarial review passes came back with zero confirmed findings. The load-bearing questions were settled explicitly: the cache key derives from prompt content, not the marker fields, so the tail breakpoint moving forward each turn is Anthropic's own documented multi-turn pattern rather than a cache-defeater; the web client replays history byte-identically from local storage (append-only, injected warnings persist stably), so prefix hits are real; and conversation identity plus budget accounting are derived from the raw chat_log before the transport touches it, so nothing upstream can shift.

The one surviving observation is the honest tradeoff already in the code comment: a conversation whose turns consistently outpace the cache lifetime pays the write premium without the read payback. The measured gap distribution says that population is small and the downside per turn is bounded — and rather than argue it, we watch it: the cost dashboard now carries a net line for this mechanism (reads saved minus write premium), with an alert if it ever runs sustained-negative. Remedies, if it did: lengthen the tail's cache lifetime, or remove the breakpoint — one line either way.

Day-after check, same discipline as the last two changes: the input-token line on the Costs dashboard should visibly drop while cache reads rise to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

