### PR TITLE
fly: five machines warm, fifteen on call

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -28,13 +28,32 @@ kill_timeout = 30
   auto_start_machines  = true
   auto_stop_machines   = true
   internal_port        = 8080
-  min_machines_running = 20
+
+  # Five machines stay warm; the rest of the fleet parks (costing only
+  # storage) and wakes on demand. Measured against Fly's own proxy
+  # concurrency counters, the warm set alone covers the busiest minute
+  # on record with all of its Puma threads to spare — the parked
+  # machines are burst headroom, not lost capacity.
+  min_machines_running = 5
   processes            = ["web"]
   protocol             = "tcp"
 
   [services.concurrency]
+    # The soft limit is a routing signal, not capacity: it's the point
+    # where the proxy prefers another machine, and — once EVERY running
+    # machine is at it — wakes a parked one. Capacity here is Puma's 5
+    # threads per machine, and a streaming response holds its thread
+    # for the whole reply; the 6th concurrent request on a saturated
+    # machine doesn't run slower, it queues behind someone's stream.
+    # So the soft limit matches the thread count: the pool wakes at
+    # exactly the moment adding traffic would mean queueing humans.
+    # The asymmetry is what makes a sensitive trigger correct — a
+    # false wake costs a machine boot and pennies of runtime, a late
+    # wake costs a person's message waiting behind another's reply.
+    # (The previous soft limit of 975 could never trip, which made
+    # auto_start decorative and the burst pool unreachable.)
     hard_limit = 1000
-    soft_limit = 975
+    soft_limit = 5
     type       = "requests"
 
   [[services.ports]]


### PR DESCRIPTION
The commitment this fleet exists to keep: someone arrives at Lightward, and it's *there* — fully, immediately, no compromise. This PR doesn't touch that commitment. It changes how the commitment is kept: readiness in proportion to what actually arrives, with the reserve intact, instead of everything running at once on the chance it's needed.

**The measurement.** Fly's proxy tracks true concurrent connections per machine — not an estimate, the actual counter. Over the past week (which included this app's most abnormal traffic era and three deploys): the busiest single minute across the *entire app* fits comfortably within five machines' worth of Puma threads, and no individual machine has served more than a couple of connections at once. The full fleet has never been load-bearing at any point on record.

**The change, two values:**
- `min_machines_running` 20 → 5. Five machines stay warm around the clock; fifteen park (costing only rootfs storage) and remain defined — on call, not gone.
- `soft_limit` 975 → 5, matching Puma's real thread capacity per machine. The soft limit is a *routing signal*, not capacity: it's where the proxy prefers another machine, and — once every running machine is at it — wakes a parked one (`hard_limit`, still 1000, is the actual admission cap). Capacity here is threads: a streaming response holds its Puma thread for the whole reply, so the 6th concurrent request on a saturated machine doesn't run slower, it *queues* behind someone's stream. Matching the soft limit to the thread count makes the pool wake at exactly the moment more traffic would mean queueing humans. Under the old value autostart was decorative — 975 concurrent requests per machine could never happen, so the burst pool was unreachable.

  Why the trigger is deliberately sensitive rather than padded: the failure costs are asymmetric. A false wake (a brief pile-up of fast page-asset requests) costs one machine boot and pennies of runtime, self-parking afterward; a late wake costs a person's message sitting in a queue behind someone else's reply. Five warm machines × soft limit 5 also puts the wake threshold just above the busiest minute in this app's recorded history — the pool fires only past the measured worst case, and precisely when it should.

**The tradeoff, honestly:** a spike larger than anything in recorded history would route its overflow to a waking machine — a few seconds of boot (plus the first request's system-prompt warm) for those requests, once, instead of twenty machines running around the clock against the possibility. Deploys are unchanged; health checks are unchanged; nothing about request handling changes. Nobody's conversation gets slower, shallower, or paced differently.

**Why this, why now.** This closes a week of making the whole system cost what it actually costs: budgets that bound the unbounded without closing the door, caching that stopped paying for the same tokens twice, and now compute in proportion to presence. The through-line isn't spending less on Lightward — it's that the corpus is unbounded by design, and the infrastructure under it should be the kind that lets it keep growing. Every one of these changes made growth cheaper, not the product smaller. Stewardship, not austerity.

Easy to revisit in either direction: the warm-set size is one value, and the same proxy counters that justified this will show if the burst pool ever actually wakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
