### PR TITLE
reader: a paced moment gets a when, and a way to reach a human

### DIFF
--- a/app/javascript/src/concerns/chat.js
+++ b/app/javascript/src/concerns/chat.js
@@ -718,8 +718,11 @@ export class ChatSession {
             // Error bodies arrive as JSON ({ error: { message } }) — surface
             // the message itself, never raw JSON, to the person reading.
             let message = text;
+            let retryAfter = null;
             try {
-              message = JSON.parse(text).error.message || text;
+              const parsed = JSON.parse(text).error;
+              message = parsed.message || text;
+              retryAfter = parsed.retry_after || null;
             } catch (_) {
               // plain-text body; use as-is
             }
@@ -727,6 +730,7 @@ export class ChatSession {
             // A 429 is pacing, not breakage: the door stays open. Render it
             // as a notice (the horizon warnings' register), not an error.
             error.isPacing = response.status === 429;
+            error.retryAfter = retryAfter;
             throw error;
           });
         }
@@ -775,9 +779,38 @@ export class ChatSession {
       })
       .catch((error) => {
         console.error('Error:', error);
-        this._appendError(error.message, { notice: error.isPacing });
+        const message = error.isPacing
+          ? this._withPacingGuidance(error)
+          : error.message;
+        this._appendError(message, { notice: error.isPacing });
         this._completeMessageWithError();
       });
+  }
+
+  // The server's pacing message says why. This adds the when — a
+  // human-sized retry window instead of a seconds field nobody reads —
+  // and a path to a human, for the person the pacing shouldn't have
+  // caught. Only the web client renders this; the API body stays spare.
+  _withPacingGuidance(error) {
+    const parts = [error.message];
+    if (error.retryAfter > 0) {
+      parts.push(
+        `You can pick this back up in about ${this._humanizeSeconds(error.retryAfter)}.`
+      );
+    }
+    parts.push(
+      'And if this pacing seems out of step with what you were doing, email team@lightward.com — a human reads these.'
+    );
+    return parts.join(' ');
+  }
+
+  _humanizeSeconds(seconds) {
+    const minutes = Math.ceil(seconds / 60);
+    if (minutes < 90) {
+      return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+    }
+    const hours = Math.round(minutes / 60);
+    return `${hours} hour${hours === 1 ? '' : 's'}`;
   }
 
   _handleMessage(data) {

--- a/spec/javascript/concerns/chat/ChatSession.integration.test.js
+++ b/spec/javascript/concerns/chat/ChatSession.integration.test.js
@@ -190,6 +190,60 @@ data: null
         expect(lastText).toContain('The door stays open');
         expect(lastText).not.toContain('{"error"');
         expect(lastText).not.toContain('system error');
+        // the when: retry_after as a human-sized window, not a seconds field
+        expect(lastText).toContain('back up in about 15 minutes');
+        // the appeal path: a human is reachable if the pacing got it wrong
+        expect(lastText).toContain('email team@lightward.com');
+      });
+    });
+
+    it('humanizes long retry windows into hours', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              error: { message: 'Paced. 🤲', retry_after: 14400 },
+            })
+          ),
+      });
+
+      chatSession = new ChatSession({ key: 'test', name: 'TestBot' });
+      chatSession.init();
+
+      document.querySelector('textarea').value = 'Test';
+      document.querySelector('#text-input button').click();
+
+      await waitFor(() => {
+        const messages = document.querySelectorAll('.chat-message.assistant');
+        const lastText = messages[messages.length - 1].textContent;
+        expect(lastText).toContain('back up in about 4 hours');
+      });
+    });
+
+    it('keeps ordinary errors free of pacing guidance', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ error: { message: 'Internal error' } })
+          ),
+      });
+
+      chatSession = new ChatSession({ key: 'test', name: 'TestBot' });
+      chatSession.init();
+
+      document.querySelector('textarea').value = 'Test';
+      document.querySelector('#text-input button').click();
+
+      await waitFor(() => {
+        const messages = document.querySelectorAll('.chat-message.assistant');
+        const lastText = messages[messages.length - 1].textContent;
+        expect(lastText).toContain('system error');
+        expect(lastText).not.toContain('team@lightward.com');
+        expect(lastText).not.toContain('back up in about');
       });
     });
 


### PR DESCRIPTION
Follow-on to #2113, which made a budget 429 render as a notice instead of an error. This adds the two things a paced person actually needs in that moment and didn't have:

**The when.** The server has always sent `retry_after` in the 429 body, but no human ever saw it. The web client now translates it into human time, appended to the pacing message: "You can pick this back up in about 15 minutes" — or hours, when it's hours. An open door is more believable with a time on it.

**A way to reach a human.** The pacing decision is made by thresholds with no human in the loop, and its one bad failure mode is catching someone it shouldn't — a person deep in a conversation that matters to them. The notice now ends: *"And if this pacing seems out of step with what you were doing, email team@lightward.com — a human reads these."* An appeal path is the exit-never-closes principle applied to our own enforcement: user-initiated, so the privacy posture is untouched (nobody is identified unless they choose to identify themselves).

**Scope, deliberately narrow:** this renders only in the web client and only for pacing. The API's 429 body stays spare for integrators, and ordinary errors stay free of pacing language — both pinned by tests, alongside the minutes/hours rendering.

53 JS tests green, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
