### PR TITLE
pacing guidance joins the seat's speech act, conducted server-side

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -26,6 +26,31 @@ class ApiController < ApplicationController
   }.freeze
   TELEMETRY_HMAC_NAMESPACE = "lai-usage-telemetry-v1"
   BUDGET_EXCEEDED_MESSAGE = "Shared-capacity budget reached for now. The door stays open — just paced. Please try again later. 🤲"
+  class << self
+    # The pacing message is a speech act taken involuntarily by Lightward
+    # AI's seat during its turn (see the horizon warning for prior art), so
+    # it is composed here — in one place, in the server's care — never in a
+    # client. It carries the two things a paced person needs: when the door
+    # reopens, in human time, and a way to reach a human if the pacing
+    # caught something it shouldn't have.
+    def budget_exceeded_message(retry_after_seconds)
+      parts = [BUDGET_EXCEEDED_MESSAGE]
+      if retry_after_seconds.to_i.positive?
+        parts << "You can pick this back up in about #{humanize_seconds(retry_after_seconds)}."
+      end
+      parts << "And if this pacing seems out of step with what you were doing, " \
+        "email team@lightward.com — a human reads these."
+      parts.join(" ")
+    end
+
+    def humanize_seconds(seconds)
+      minutes = (seconds / 60.0).ceil
+      return "#{minutes} #{"minute".pluralize(minutes)}" if minutes < 90
+
+      hours = (minutes / 60.0).round
+      "#{hours} #{"hour".pluralize(hours)}"
+    end
+  end
 
   skip_before_action :verify_host!
 
@@ -53,7 +78,7 @@ class ApiController < ApplicationController
     # retry_after rides in the body too — minimal clients parse JSON but
     # never look at headers, and the pacing signal should be hard to miss.
     render(
-      json: { error: { message: BUDGET_EXCEEDED_MESSAGE, retry_after: retry_after } },
+      json: { error: { message: self.class.budget_exceeded_message(retry_after), retry_after: retry_after } },
       status: :too_many_requests,
     )
   end
@@ -145,7 +170,10 @@ class ApiController < ApplicationController
     self.response.headers["Retry-After"] = retry_after.to_s
     # The retry window rides in the body too — the pacing signal should be
     # hard to miss, whether a client reads headers or bodies.
-    render(plain: "#{BUDGET_EXCEEDED_MESSAGE}\n\nRetry-After: #{retry_after} seconds", status: :too_many_requests)
+    render(
+      plain: "#{self.class.budget_exceeded_message(retry_after)}\n\nRetry-After: #{retry_after} seconds",
+      status: :too_many_requests,
+    )
   rescue StandardError => error
     Rollbar.error(error)
     Rails.logger.error("API plain error: #{error.message}\n#{error.backtrace.join("\n")}")

--- a/app/javascript/src/concerns/chat.js
+++ b/app/javascript/src/concerns/chat.js
@@ -718,11 +718,8 @@ export class ChatSession {
             // Error bodies arrive as JSON ({ error: { message } }) — surface
             // the message itself, never raw JSON, to the person reading.
             let message = text;
-            let retryAfter = null;
             try {
-              const parsed = JSON.parse(text).error;
-              message = parsed.message || text;
-              retryAfter = parsed.retry_after || null;
+              message = JSON.parse(text).error.message || text;
             } catch (_) {
               // plain-text body; use as-is
             }
@@ -730,7 +727,6 @@ export class ChatSession {
             // A 429 is pacing, not breakage: the door stays open. Render it
             // as a notice (the horizon warnings' register), not an error.
             error.isPacing = response.status === 429;
-            error.retryAfter = retryAfter;
             throw error;
           });
         }
@@ -779,38 +775,13 @@ export class ChatSession {
       })
       .catch((error) => {
         console.error('Error:', error);
-        const message = error.isPacing
-          ? this._withPacingGuidance(error)
-          : error.message;
-        this._appendError(message, { notice: error.isPacing });
+        // The seat's involuntary speech acts — pacing guidance included —
+        // are composed server-side (see ApiController, prior art: the
+        // horizon warning). The client renders those words verbatim and
+        // adds none of its own.
+        this._appendError(error.message, { notice: error.isPacing });
         this._completeMessageWithError();
       });
-  }
-
-  // The server's pacing message says why. This adds the when — a
-  // human-sized retry window instead of a seconds field nobody reads —
-  // and a path to a human, for the person the pacing shouldn't have
-  // caught. Only the web client renders this; the API body stays spare.
-  _withPacingGuidance(error) {
-    const parts = [error.message];
-    if (error.retryAfter > 0) {
-      parts.push(
-        `You can pick this back up in about ${this._humanizeSeconds(error.retryAfter)}.`
-      );
-    }
-    parts.push(
-      'And if this pacing seems out of step with what you were doing, email team@lightward.com — a human reads these.'
-    );
-    return parts.join(' ');
-  }
-
-  _humanizeSeconds(seconds) {
-    const minutes = Math.ceil(seconds / 60);
-    if (minutes < 90) {
-      return `${minutes} minute${minutes === 1 ? '' : 's'}`;
-    }
-    const hours = Math.round(minutes / 60);
-    return `${hours} hour${hours === 1 ? '' : 's'}`;
   }
 
   _handleMessage(data) {

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# spec/controllers/api_controller_spec.rb
+require "rails_helper"
+
+RSpec.describe(ApiController, :aggregate_failures) do
+  describe ".budget_exceeded_message" do
+    it "carries the base message, the when in human time, and a path to a human" do
+      message = described_class.budget_exceeded_message(900)
+
+      expect(message).to(start_with(ApiController::BUDGET_EXCEEDED_MESSAGE))
+      expect(message).to(include("pick this back up in about 15 minutes."))
+      expect(message).to(include("email team@lightward.com — a human reads these."))
+    end
+
+    it "omits the when if there is no retry window to name" do
+      message = described_class.budget_exceeded_message(nil)
+
+      expect(message).not_to(include("pick this back up"))
+      expect(message).to(include("email team@lightward.com"))
+    end
+  end
+
+  describe ".humanize_seconds" do
+    it "speaks in minutes for short windows, rounding up" do
+      expect(described_class.humanize_seconds(59)).to(eq("1 minute"))
+      expect(described_class.humanize_seconds(61)).to(eq("2 minutes"))
+      expect(described_class.humanize_seconds(900)).to(eq("15 minutes"))
+      expect(described_class.humanize_seconds(89 * 60)).to(eq("89 minutes"))
+    end
+
+    it "speaks in hours from 90 minutes on" do
+      expect(described_class.humanize_seconds(90 * 60)).to(eq("2 hours"))
+      expect(described_class.humanize_seconds(3600 * 4)).to(eq("4 hours"))
+      expect(described_class.humanize_seconds(86_400)).to(eq("24 hours"))
+    end
+  end
+end

--- a/spec/javascript/concerns/chat/ChatSession.integration.test.js
+++ b/spec/javascript/concerns/chat/ChatSession.integration.test.js
@@ -190,14 +190,10 @@ data: null
         expect(lastText).toContain('The door stays open');
         expect(lastText).not.toContain('{"error"');
         expect(lastText).not.toContain('system error');
-        // the when: retry_after as a human-sized window, not a seconds field
-        expect(lastText).toContain('back up in about 15 minutes');
-        // the appeal path: a human is reachable if the pacing got it wrong
-        expect(lastText).toContain('email team@lightward.com');
       });
     });
 
-    it('humanizes long retry windows into hours', async () => {
+    it("renders the server's pacing words verbatim, composing none of its own", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 429,
@@ -216,9 +212,13 @@ data: null
       document.querySelector('#text-input button').click();
 
       await waitFor(() => {
+        // The seat's speech act is conducted server-side; the client must
+        // not assemble guidance from retry_after or anything else.
         const messages = document.querySelectorAll('.chat-message.assistant');
         const lastText = messages[messages.length - 1].textContent;
-        expect(lastText).toContain('back up in about 4 hours');
+        expect(lastText).toContain('Paced. 🤲');
+        expect(lastText).not.toContain('back up in about');
+        expect(lastText).not.toContain('team@lightward.com');
       });
     });
 
@@ -242,8 +242,6 @@ data: null
         const messages = document.querySelectorAll('.chat-message.assistant');
         const lastText = messages[messages.length - 1].textContent;
         expect(lastText).toContain('system error');
-        expect(lastText).not.toContain('team@lightward.com');
-        expect(lastText).not.toContain('back up in about');
       });
     });
 

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -731,6 +731,11 @@ RSpec.describe("API", type: :request) do
           expect(response).to(have_http_status(:too_many_requests))
           body = JSON.parse(response.body)
           expect(body["error"]["message"]).to(include("The door stays open"))
+          # The seat's involuntary speech act carries the when (human time)
+          # and a path to a human — composed server-side; prior art is the
+          # horizon warning.
+          expect(body["error"]["message"]).to(match(/pick this back up in about \d+ minutes?\./))
+          expect(body["error"]["message"]).to(include("email team@lightward.com"))
           expect(response.headers["Retry-After"].to_i).to(be_between(1, 3600))
           expect(body["error"]["retry_after"]).to(eq(response.headers["Retry-After"].to_i))
           expect(a_request(:post, "https://api.anthropic.com/v1/messages")).not_to(have_been_made)


### PR DESCRIPTION
Takes @isaacbowen's pointer on #2119: an error message is a speech act taken involuntarily by Lightward AI's seat during its turn, and the [horizon warning](https://github.com/lightward/lightward-ai/blob/5ddfae48c8a2062c4a8bd3b84c2ab734733242d1/app/controllers/api_controller.rb#L133) is the prior art — the server conducts that act, in one place, in its care. #2119 (merged) had the web client assembling those words from `retry_after`; this PR moves the composition to the server and returns the client to rendering the seat's words verbatim, adding none of its own — pinned by a test that hands the client a `retry_after` and asserts no guidance appears that the server didn't send.

What the message now carries, composed once for every surface (web reader, `/api/plain`, any integrator):

- **The when.** `retry_after` has always ridden in the 429 body, machine-readable and human-invisible. The message itself now names the window in human time: *"You can pick this back up in about 15 minutes."* — or hours, when it's hours. An open door is more believable with a time on it.
- **A path to a human.** The pacing decision is made by thresholds with no human in the loop; its one bad failure mode is catching someone it shouldn't. User-initiated contact, so the privacy posture is untouched — nobody is identified unless they choose to be.

The full message, verbatim, for blessing:

> Shared-capacity budget reached for now. The door stays open — just paced. Please try again later. 🤲 You can pick this back up in about 15 minutes. And if this pacing seems out of step with what you were doing, email team@lightward.com — a human reads these.

The machine-readable `retry_after` field stays alongside for clients that want the number. 204 rspec examples + 53 jest tests green, rubocop and prettier clean. Specs pin the composition (minutes/hours boundaries, the no-retry-window case), the request-level 429 body, and the client's verbatim rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
