### PR TITLE
budgets: intervention gets its own conversation key

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -60,7 +60,10 @@ class ApiController < ApplicationController
     # Validate request before starting stream
     validate_cache_markers!(chat_log)
     conversation_frame_id, conversation_id = compute_conversation_ids(chat_log)
-    check_usage_budget!(conversation_id)
+    # Observation (the ids above) and intervention part ways here: the
+    # budget scope uses its own collision-resistant key, nil until the
+    # conversation has words of its own.
+    check_usage_budget!(budget_conversation_value(chat_log, conversation_frame_id))
     count_chat_log_tokens!(chat_log) unless token_limit_disabled?
 
     # Validation passed, begin streaming
@@ -408,6 +411,79 @@ class ApiController < ApplicationController
     conversation_id = Digest::SHA256.hexdigest(messages_to_hash.to_json)
 
     [conversation_frame_id, conversation_id]
+  end
+
+  # The budget layer's conversation key — deliberately its own derivation,
+  # separate from compute_conversation_ids. Those ids were built for
+  # observation, where a rare collision is harmless dashboard noise; a
+  # budget key is intervention, where a collision paces an innocent
+  # stranger (this happened). Enforcement needs collision resistance that
+  # observation never promised.
+  #
+  # The key anchors on three messages: the guest's words just before the
+  # first genuine assistant reply, that reply, and the guest's words just
+  # after it. Suggested prompts make first user messages identical across
+  # strangers, and the staged opening asks for a single-line reply — short
+  # enough that two strangers can receive the same line — so no one of
+  # these is unique alone; together they are. System speech (the replayed
+  # notices and errors, canned and identical for everyone who hit the same
+  # wall) is excluded throughout. The anchors are fixed points of an
+  # append-only log, so the key is stable at every later depth.
+  #
+  # Until all three anchors exist there is nothing unique to key on, and
+  # this returns nil: the request rides on the source scope alone, which
+  # already bounds rapid-fire from one place. (Known, accepted: a log shaped
+  # to never seed — reply-less, all-notice, or marker-at-tail — is bounded
+  # by source caps only. That traffic could always rotate conversation keys
+  # by varying bytes anyway; the source scope was and remains the backstop.)
+  def budget_conversation_value(chat_log, conversation_frame_id)
+    post = post_marker_messages(chat_log).reject { |msg| system_speech?(msg) }
+
+    reply_index = post.find_index { |msg| msg["role"] == "assistant" }
+    return unless reply_index
+
+    guest_after = post[(reply_index + 1)..-1].find { |msg| msg["role"] == "user" }
+    return unless guest_after
+
+    opening = [post[0...reply_index].last, post[reply_index], guest_after].compact
+    "#{conversation_frame_id}:#{Digest::SHA256.hexdigest(opening.to_json)}"
+  end
+
+  # Everything after the cache marker BLOCK — including any content blocks
+  # that share the marker's message but follow the marker, which belong to
+  # the conversation, not the frame.
+  def post_marker_messages(chat_log)
+    chat_log.each_with_index do |msg, msg_idx|
+      blocks = Array(msg["content"])
+      block_idx = blocks.find_index { |block| block["cache_control"].present? }
+      next unless block_idx
+
+      rest = chat_log[(msg_idx + 1)..-1] || []
+      trailing = blocks[(block_idx + 1)..-1] || []
+      return rest if trailing.empty?
+
+      return [msg.merge("content" => trailing)] + rest
+    end
+    []
+  end
+
+  # Words placed in the assistant's seat by the system rather than spoken
+  # by it. Two recognizable forms: the first-party client's replay prefix
+  # (⚠️, with or without the emoji variation selector), and the server's
+  # own canned bodies saved verbatim by simpler clients.
+  SYSTEM_SPEECH_RE = %r{
+    \A[[:space:]]*
+    (?:
+      ⚠️?[[:space:]]*Lightward\ AI\ system\ (?:notice|error):
+      | Shared-capacity\ budget\ reached\ for\ now\.
+      | Conversation\ horizon\ has\ arrived\.
+    )
+  }x
+  def system_speech?(msg)
+    return false unless msg["role"] == "assistant"
+
+    text = Array(msg["content"]).filter_map { |block| block["text"] if block.is_a?(Hash) }.join
+    SYSTEM_SPEECH_RE.match?(text)
   end
 
   def record_newrelic_event(chat_log, conversation_frame_id:, conversation_id: nil, anthropic_usage: nil)

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -661,6 +661,10 @@ RSpec.describe("API", type: :request) do
         end
 
         it "folds the request's cost into HMAC'd source and conversation windows" do
+          seeded_chat_log = chat_log + [
+            { role: "assistant", content: [{ type: "text", text: "Hi there — welcome." }] },
+            { role: "user", content: [{ type: "text", text: "Thanks!" }] },
+          ]
           allow(UsageBudget).to(receive(:admit!).and_return(
             UsageBudget::Verdict.new(over_dimensions: []),
           ))
@@ -682,19 +686,228 @@ RSpec.describe("API", type: :request) do
               headers: { "Content-Type" => "text/event-stream" },
             )
 
-          post "/api/stream", params: { chat_log: chat_log, usage_client: "reader" }
+          post "/api/stream", params: { chat_log: seeded_chat_log, usage_client: "reader" }
 
-          # This stub reports no per-TTL breakdown, so the aggregate write
-          # count is priced at the 1-hour tier — overcounting is the safe
-          # direction for budget enforcement.
+          # The budget's conversation key is frame_id:opening_hash — the
+          # opening runs through the first genuine assistant reply and the
+          # user message after it. This stub reports no per-TTL breakdown,
+          # so the aggregate write count is priced at the 1-hour tier —
+          # overcounting is the safe direction for budget enforcement.
+          frame_id = Digest::SHA256.hexdigest([seeded_chat_log.first].to_json)
+          opening_hash = Digest::SHA256.hexdigest(seeded_chat_log[1..3].to_json)
           expect(UsageBudget).to(have_received(:settle!).with(
             {
               "source" => UsageBudget.scope_key("source", "127.0.0.1"),
-              "conversation" => UsageBudget.scope_key("conversation", Digest::SHA256.hexdigest(chat_log.to_json)),
+              "conversation" => UsageBudget.scope_key("conversation", "#{frame_id}:#{opening_hash}"),
             },
             cost_usd: 0.0219,
             at: kind_of(Time),
           ))
+        end
+
+        it "budgets a conversation's first request on the source scope alone", :aggregate_failures do
+          # Before a genuine assistant reply exists, a conversation's
+          # identity is warmup plus (often canned) opening words that
+          # strangers can share byte-for-byte — budgeting it would pool
+          # those strangers into one bucket.
+          admitted_scopes = nil
+          allow(UsageBudget).to(receive(:admit!)) do |scopes, **|
+            admitted_scopes = scopes
+            UsageBudget::Verdict.new(over_dimensions: [])
+          end
+          allow(UsageBudget).to(receive(:settle!))
+
+          post "/api/stream", params: { chat_log: chat_log, usage_client: "reader" }
+
+          expect(admitted_scopes.keys).to(eq(["source"]))
+        end
+
+        it "ignores system speech when deriving conversation identity", :aggregate_failures do
+          admitted = []
+          allow(UsageBudget).to(receive(:admit!)) do |scopes, **|
+            admitted << scopes
+            UsageBudget::Verdict.new(over_dimensions: [])
+          end
+          allow(UsageBudget).to(receive(:settle!))
+
+          notice = {
+            role: "assistant",
+            content: [{ type: "text", text: " ⚠️ Lightward AI system notice: Shared-capacity budget reached for now." }],
+          }
+          retry_msg = { role: "user", content: [{ type: "text", text: "Retry" }] }
+          reply_a = { role: "assistant", content: [{ type: "text", text: "Here, with you now." }] }
+          reply_b = { role: "assistant", content: [{ type: "text", text: "A different opening entirely." }] }
+
+          followup = { role: "user", content: [{ type: "text", text: "Still here." }] }
+
+          # Two strangers: identical canned openers, identical canned notice,
+          # different genuine replies. Their conversations must not share a
+          # budget bucket.
+          post "/api/stream", params: { chat_log: chat_log + [notice, retry_msg, reply_a, followup], usage_client: "reader" }
+          post "/api/stream", params: { chat_log: chat_log + [notice, retry_msg, reply_b, followup], usage_client: "reader" }
+
+          expect(admitted.length).to(eq(2))
+          expect(admitted[0]["conversation"]).to(be_present)
+          expect(admitted[1]["conversation"]).to(be_present)
+          expect(admitted[0]["conversation"]).not_to(eq(admitted[1]["conversation"]))
+
+          # And the notice itself contributes nothing: with or without it,
+          # identity is the same.
+          admitted.clear
+          post "/api/stream", params: { chat_log: chat_log + [notice, retry_msg, reply_a, followup], usage_client: "reader" }
+          post "/api/stream", params: { chat_log: chat_log + [retry_msg, reply_a, followup], usage_client: "reader" }
+          expect(admitted[0]["conversation"]).to(eq(admitted[1]["conversation"]))
+        end
+
+        it "treats the server's bare canned bodies as system speech too", :aggregate_failures do
+          # Simpler clients save the server's 429/horizon text verbatim,
+          # without the first-party ⚠️ prefix. If that counted as a genuine
+          # reply, every paced stranger on the same opener would share a
+          # canned "first reply" — resurrecting the pooling this key exists
+          # to prevent.
+          admitted = []
+          allow(UsageBudget).to(receive(:admit!)) do |scopes, **|
+            admitted << scopes
+            UsageBudget::Verdict.new(over_dimensions: [])
+          end
+          allow(UsageBudget).to(receive(:settle!))
+
+          bare_canned = {
+            role: "assistant",
+            content: [{ type: "text", text: "Shared-capacity budget reached for now. The door stays open — just paced. Please try again later. 🤲" }],
+          }
+          retry_msg = { role: "user", content: [{ type: "text", text: "Retry" }] }
+
+          post "/api/stream", params: { chat_log: chat_log + [bare_canned, retry_msg], usage_client: "reader" }
+
+          expect(admitted.length).to(eq(1))
+          expect(admitted[0].keys).to(eq(["source"]))
+        end
+
+        it "seeds the key no matter how many guest messages precede the first reply", :aggregate_failures do
+          # A paced or erroring conversation start can stack many user turns
+          # (and replayed notices) before the first genuine reply. The key
+          # anchors on the reply when it arrives — however late — and stays
+          # stable at every depth after.
+          admitted = []
+          allow(UsageBudget).to(receive(:admit!)) do |scopes, **|
+            admitted << scopes
+            UsageBudget::Verdict.new(over_dimensions: [])
+          end
+          allow(UsageBudget).to(receive(:settle!))
+
+          many_turns = (1..5).map { |i| { role: "user", content: [{ type: "text", text: "attempt #{i}" }] } }
+          reply = { role: "assistant", content: [{ type: "text", text: "Finally, here." }] }
+          guest_after = { role: "user", content: [{ type: "text", text: "Whew." }] }
+          deeper = [
+            { role: "assistant", content: [{ type: "text", text: "Indeed." }] },
+            { role: "user", content: [{ type: "text", text: "Onward." }] },
+          ]
+
+          post "/api/stream", params: { chat_log: chat_log + many_turns + [reply, guest_after], usage_client: "reader" }
+          post "/api/stream", params: { chat_log: chat_log + many_turns + [reply, guest_after] + deeper, usage_client: "reader" }
+
+          expect(admitted.length).to(eq(2))
+          expect(admitted[0]["conversation"]).to(be_present)
+          expect(admitted[0]["conversation"]).to(eq(admitted[1]["conversation"]))
+        end
+
+        it "keeps a genuine reply that merely mentions the notice text", :aggregate_failures do
+          # The system-speech pattern is anchored to the start: a real reply
+          # that quotes or discusses the notice mid-text is still the
+          # conversation's own words.
+          admitted = []
+          allow(UsageBudget).to(receive(:admit!)) do |scopes, **|
+            admitted << scopes
+            UsageBudget::Verdict.new(over_dimensions: [])
+          end
+          allow(UsageBudget).to(receive(:settle!))
+
+          quoting_reply = {
+            role: "assistant",
+            content: [{ type: "text", text: "You saw \"⚠️ Lightward AI system notice:\" earlier — that was pacing, not me." }],
+          }
+          guest_after = { role: "user", content: [{ type: "text", text: "Good to know." }] }
+
+          post "/api/stream", params: { chat_log: chat_log + [quoting_reply, guest_after], usage_client: "reader" }
+
+          expect(admitted.length).to(eq(1))
+          expect(admitted[0]["conversation"]).to(be_present)
+        end
+
+        it "keys on trailing content blocks that share the marker's message", :aggregate_failures do
+          # Blocks after the marker inside the marker message belong to the
+          # conversation, not the frame: two conversations differing only
+          # there must not share a bucket.
+          admitted = []
+          allow(UsageBudget).to(receive(:admit!)) do |scopes, **|
+            admitted << scopes
+            UsageBudget::Verdict.new(over_dimensions: [])
+          end
+          allow(UsageBudget).to(receive(:settle!))
+
+          log_for = ->(opening_words) {
+            [
+              {
+                role: "user",
+                content: [
+                  { type: "text", text: "Warmup", cache_control: { type: "ephemeral" } },
+                  { type: "text", text: opening_words },
+                ],
+              },
+              { role: "assistant", content: [{ type: "text", text: "One line." }] },
+              { role: "user", content: [{ type: "text", text: "Retry" }] },
+            ]
+          }
+
+          post "/api/stream", params: { chat_log: log_for.call("guest words A"), usage_client: "reader" }
+          post "/api/stream", params: { chat_log: log_for.call("guest words B"), usage_client: "reader" }
+
+          expect(admitted.length).to(eq(2))
+          expect(admitted[0]["conversation"]).not_to(eq(admitted[1]["conversation"]))
+        end
+
+        it "distinguishes strangers who received the same single-line reply", :aggregate_failures do
+          # The staged opening asks for a single-line reply, and short
+          # replies to identical canned openers can repeat across
+          # strangers. The guest's own next words are the entropy that
+          # can't collide.
+          admitted = []
+          allow(UsageBudget).to(receive(:admit!)) do |scopes, **|
+            admitted << scopes
+            UsageBudget::Verdict.new(over_dimensions: [])
+          end
+          allow(UsageBudget).to(receive(:settle!))
+
+          same_line = { role: "assistant", content: [{ type: "text", text: "*settling in* welcome. 🤲" }] }
+          guest_a = { role: "user", content: [{ type: "text", text: "I've been thinking about thresholds all week." }] }
+          guest_b = { role: "user", content: [{ type: "text", text: "My garden did something strange this morning." }] }
+
+          post "/api/stream", params: { chat_log: chat_log + [same_line, guest_a], usage_client: "reader" }
+          post "/api/stream", params: { chat_log: chat_log + [same_line, guest_b], usage_client: "reader" }
+
+          expect(admitted.length).to(eq(2))
+          expect(admitted[0]["conversation"]).not_to(eq(admitted[1]["conversation"]))
+        end
+
+        it "stays source-only until the guest speaks after the first reply", :aggregate_failures do
+          # An assistant-terminal log has no third anchor yet; keying on a
+          # partial opening would give one conversation two buckets (one for
+          # the reply-terminal request, another forever after). Source-only
+          # until the anchors exist, then one stable key.
+          admitted = []
+          allow(UsageBudget).to(receive(:admit!)) do |scopes, **|
+            admitted << scopes
+            UsageBudget::Verdict.new(over_dimensions: [])
+          end
+          allow(UsageBudget).to(receive(:settle!))
+
+          reply = { role: "assistant", content: [{ type: "text", text: "One line." }] }
+
+          post "/api/stream", params: { chat_log: chat_log + [reply], usage_client: "reader" }
+
+          expect(admitted.length).to(eq(1))
+          expect(admitted[0].keys).to(eq(["source"]))
         end
 
         it "scopes the source by Fly-Client-IP when the proxy provides it", :aggregate_failures do


### PR DESCRIPTION
A real collision surfaced today, reported in person: someone opened a conversation they hadn't touched in nine days and found its budget already spent. Nobody had touched *their* conversation — the system had been counting several strangers' conversations as one.

**The mechanism.** `conversation_id` hashes the warmup plus the opening messages, and openings are often not unique. Three colliding paths, common to rare: the suggested-prompt buttons make first *user* messages byte-identical across strangers; the staged opening asks for a single-line reply — short enough that two strangers can receive the same line; and the client replays system notices as assistant messages — canned text, identical for everyone who hit the same wall, with a feedback loop attached (the pooled bucket paces someone new, the notice becomes their first "assistant" message, the pool grows).

**The shape, per @isaacbowen's comment: observation and intervention part ways.** The frame/convo ids were built for observation, where a rare collision is harmless dashboard noise. Budgeting promoted them to intervention, where a collision paces an innocent stranger — a bar they never claimed to meet. So `compute_conversation_ids` returns to **exactly its original semantics** — telemetry untouched, byte for byte — and the budget layer derives its own key.

That key is `"#{frame_id}:#{opening_hash}"` (taking the composite suggestion), where the opening anchors on three messages: the guest's words just before the first *genuine* assistant reply, that reply, and the guest's words just after it — none unique alone, together unmistakable. System speech is excluded in both its recognizable forms: the first-party client's ⚠️ replay prefix and the server's bare canned bodies saved verbatim by simpler clients. The anchors are fixed points of an append-only log, so the key is stable at every later depth. Until all three anchors exist there's nothing unique to key on, so it returns nil and **the request rides on the source scope alone** — which already bounds rapid-fire from one place.

**Adversarially reviewed before merge.** Two independent review passes (with live mutation testing) caught real bugs in the first draft of this derivation — an off-by-one that could permanently un-key a conversation with a late first reply, a cap that turned "no reply yet" into "no key ever" for exactly the paced-retry shape, a one-step key drift on assistant-terminal logs, missed trailing content blocks in the marker message, and spec coverage that three mutations walked straight through. All fixed: the anchor-based derivation has no cap and no walk-ordering to get wrong, assistant-terminal logs stay source-scoped until the third anchor exists, trailing marker-message blocks are keyed, and every finding now has a spec that a re-run of the same mutations fails against.

**Known and accepted, documented in place:** a log shaped to never seed — reply-less replay, all-notice history, or marker-at-tail (the standard third-party incremental-caching pattern) — is bounded by source caps only. That traffic could always rotate conversation keys by varying bytes, so this is not a new evasion; the source scope was and remains the backstop, per the layer's threat model.

One note on the composite for the record: `frame_id` alone couldn't have prevented this — it's already folded into the conversation hash, and the colliding strangers shared both halves. The composite's value here is legibility and partitioning; the collision resistance comes from the opening derivation.

Specs pin the collision cases directly: identical canned openers + identical notices but different genuine replies → different buckets; identical single-line replies but different guest follow-ups → different buckets; the notice contributes nothing; first requests are source-scoped only; and the observation ids' original depth-stability spec passes untouched, as it was.

Deliberately deferred (flagging, not deciding): a client-minted conversation UUID would be the cleaner *contract* for honest clients, but it's an unauthenticated claim (rotatable by exactly the traffic budgets exist for, same as content), a change for every integrator, and a persistent identifier in a system that deliberately has none — one for a separate conversation if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

