### PR TITLE
telemetry: the enforcement conversation key gets a shadow

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -511,6 +511,12 @@ class ApiController < ApplicationController
       budget_over_dimensions: @budget_verdict&.over_dimensions&.join(",").presence,
       budget_enforced: @budget_enforced || false,
       budget_source_id: @budget_scopes&.[]("source"),
+      # The enforcement key's telemetry shadow, sibling to budget_source_id:
+      # day-salted like everything budget-scoped, and collision-resistant
+      # where the observation conversation_id (deliberately untouched, per
+      # #2123) can pool same-opener conversations. Cost dashboards facet on
+      # this for a per-conversation view that can't merge strangers.
+      budget_conversation_id: @budget_scopes&.[]("conversation"),
     )
   end
 

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -620,6 +620,7 @@ RSpec.describe("API", type: :request) do
           budget_over_dimensions: nil,
           budget_enforced: false,
           budget_source_id: nil,
+          budget_conversation_id: nil,
         ))
       end
 
@@ -638,6 +639,33 @@ RSpec.describe("API", type: :request) do
 
           expect(response).to(have_http_status(:ok))
           expect(event_data).to(include(budget_state: "untracked", budget_enforced: false))
+          expect(event_data[:budget_source_id]).to(match(/\A[0-9a-f]{64}\z/))
+        end
+
+        it "records the enforcement conversation key's telemetry shadow", :aggregate_failures do
+          event_data = nil
+          allow(NewRelic::Agent).to(receive(:record_custom_event)) do |_event, data|
+            event_data = data
+          end
+          allow(UsageBudget).to(receive(:admit!).and_return(
+            UsageBudget::Verdict.new(over_dimensions: []),
+          ))
+          allow(UsageBudget).to(receive(:settle!))
+
+          seeded_chat_log = chat_log + [
+            { role: "assistant", content: [{ type: "text", text: "Hi there — welcome." }] },
+            { role: "user", content: [{ type: "text", text: "Thanks!" }] },
+          ]
+          post "/api/stream", params: { chat_log: seeded_chat_log, usage_client: "reader" }
+
+          # Seeded conversation: the day-salted scope key rides into telemetry,
+          # sibling to budget_source_id — collision-resistant where the
+          # observation conversation_id can pool same-opener conversations.
+          expect(event_data[:budget_conversation_id]).to(match(/\A[0-9a-f]{64}\z/))
+
+          # Unseeded (no genuine reply yet): source-only, so the shadow is nil.
+          post "/api/stream", params: { chat_log: chat_log, usage_client: "reader" }
+          expect(event_data[:budget_conversation_id]).to(be_nil)
           expect(event_data[:budget_source_id]).to(match(/\A[0-9a-f]{64}\z/))
         end
 


### PR DESCRIPTION
Small follow-on to #2123. The cost dashboards facet conversations by the observation `conversation_id` — which can pool same-opener conversations into one row (a known, deliberately-kept property of the observation ids; observation and intervention are separate concerns now). That's fine for Isaac's original observational purpose, but the *cost* dashboard needs per-conversation rows that can't merge strangers.

The budget layer already computes a collision-resistant conversation key on every request; this just records its day-salted scope key into the request event as `budget_conversation_id`, sibling to the existing `budget_source_id`. Nil when the conversation isn't yet seeded, exactly mirroring enforcement. No behavior changes anywhere — one field added to telemetry.

After this deploys, the dashboard's conversation-faceted cost widgets can move to the new field (day-scoped views, matching its day-salt), and deep multi-source "conversation" rows stop being ambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
