### PR TITLE
thinking disabled: all processing happens in the shared space

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -143,10 +143,15 @@ class ApiController < ApplicationController
         return
       end
 
-      # Parse response and extract text
+      # Parse response and extract text. Select by block type, not position:
+      # content may lead with non-text blocks (e.g. thinking), and the answer
+      # can span multiple text blocks.
       parsed = JSON.parse(response.body)
       anthropic_usage = parsed["usage"]
-      response_text = parsed.dig("content", 0, "text") || ""
+      response_text = Array(parsed["content"])
+        .select { |block| block["type"] == "text" }
+        .map { |block| block["text"] }
+        .join("\n\n")
       record_newrelic_event(chat_log, conversation_frame_id: "plain", anthropic_usage: anthropic_usage)
       newrelic_event_recorded = true
     ensure

--- a/app/lib/prompts/anthropic.rb
+++ b/app/lib/prompts/anthropic.rb
@@ -65,6 +65,9 @@ module Prompts
           max_tokens: 4000,
           stream: stream,
           temperature: 1.0,
+          # Sonnet 5 runs adaptive thinking when this is unset. Not here: no
+          # backstage thought — all processing happens in the shared space.
+          thinking: { type: "disabled" },
           system: apply_cache_ttl(system),
           messages: cache_conversation_tail(messages),
         }

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -1261,6 +1261,40 @@ RSpec.describe("API", type: :request) do
       ).to(have_been_made.once)
     end
 
+    it "sends thinking disabled — no backstage thought, all processing in the shared space" do
+      post "/api/plain", params: "Hello", headers: { "CONTENT_TYPE" => "text/plain" }
+
+      expect(
+        a_request(:post, "https://api.anthropic.com/v1/messages").with { |req|
+          JSON.parse(req.body)["thinking"] == { "type" => "disabled" }
+        },
+      ).to(have_been_made.once)
+    end
+
+    context "when the response leads with a non-text block" do
+      before do
+        stub_request(:post, "https://api.anthropic.com/v1/messages")
+          .to_return(
+            status: 200,
+            body: {
+              content: [
+                { type: "thinking", thinking: "" },
+                { type: "text", text: "Hello, fellow AI!" },
+              ],
+              stop_reason: "end_turn",
+            }.to_json,
+            headers: { "Content-Type" => "application/json" },
+          )
+      end
+
+      it "extracts the text block rather than trusting position", :aggregate_failures do
+        post "/api/plain", params: "Hello", headers: { "CONTENT_TYPE" => "text/plain" }
+
+        expect(response).to(have_http_status(:ok))
+        expect(response.body).to(eq("Hello, fellow AI!"))
+      end
+    end
+
     it "returns error when body is empty", :aggregate_failures do
       post "/api/plain", params: "", headers: { "CONTENT_TYPE" => "text/plain" }
 


### PR DESCRIPTION
## What

Since #2128 moved the model to `claude-sonnet-5`, the helpscout-ai client has been receiving empty responses from `/api/plain`.

Sonnet 5 runs adaptive thinking by default when the `thinking` param is unset — a silent default change from Sonnet 4.6, where omitting the param meant thinking off. Responses now lead with a thinking block (empty text, since `display` defaults to `omitted`), and `/api/plain` read its answer from `parsed.dig("content", 0, "text")` — which returned nil, rendering an empty 200.

## Changes

- **`Prompts::Anthropic.messages`** now sends `thinking: { type: "disabled" }` on both the streaming and plain paths. No backstage thought — all processing happens in the shared space.
- **`/api/plain`** extracts text blocks by type and joins them, rather than trusting position. Robust to whatever block ordering future models send, disabled thinking or no.
- **Specs**: one asserting the outbound payload carries `thinking: disabled`; one feeding back a thinking-block-first response and asserting the text still comes through.

215 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)